### PR TITLE
Add new commands to Term and Test

### DIFF
--- a/doc/sf.txt
+++ b/doc/sf.txt
@@ -36,6 +36,26 @@ Save the file in the current buffer and push to target_org.
 Retrieve the file in the current buffer from target_org.
 
 ------------------------------------------------------------------------------
+                                                           *Sf.retrieve_package*
+                                 `Sf.retrieve_package`
+Retrieve the file in the current buffer as a manifest from target_org
+
+------------------------------------------------------------------------------
+                                                              *Sf.run_anonymous*
+                                 `Sf.run_anonymous`
+Run the file in the current buffer as anonymous apex in target_org
+
+------------------------------------------------------------------------------
+                                                                  *Sf.run_query*
+                                 `Sf.run_query`
+Run the query defined in current buffer in target_org
+
+------------------------------------------------------------------------------
+                                                          *Sf.run_tooling_query*
+                                 `Sf.run_query`
+Run the tooling API query defined in the current buffer in target_org
+
+------------------------------------------------------------------------------
                                                                      *Sf.cancel*
                                   `Sf.cancel`
 Terminate the running command in SFTerm.

--- a/doc/sf.txt
+++ b/doc/sf.txt
@@ -162,5 +162,9 @@ Run all Apex tests in the current Apex file.
                              `Sf.repeat_last_tests`
 A convenient way to repeat the last executed Apex test command.
 
+------------------------------------------------------------------------------
+                                                            *Sf.run_local_tests*
+                             `Sf.run_local_tests`
+Run all local tests in target_org
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/lua/sf/config.lua
+++ b/lua/sf/config.lua
@@ -188,6 +188,22 @@ local init = function()
       Sf.retrieve()
     end, {})
 
+    vim.api.nvim_create_user_command("SfRetrievePackage", function ()
+      Sf.retrieve_package()
+    end, {})
+
+    vim.api.nvim_create_user_command("SfRunAnonymousApex", function ()
+      Sf.run_anonymous()
+    end, {})
+
+    vim.api.nvim_create_user_command("SfRunQuery", function ()
+      Sf.run_query()
+    end, {})
+
+    vim.api.nvim_create_user_command("SfRunToolingQuery", function ()
+      Sf.run_tooling_query()
+    end, {})
+
     vim.api.nvim_create_user_command("SfCancelCommand", function()
       Sf.cancel()
     end, {})

--- a/lua/sf/config.lua
+++ b/lua/sf/config.lua
@@ -220,6 +220,10 @@ local init = function()
       Sf.repeat_last_tests()
     end, {})
 
+    vim.api.nvim_create_user_command("SfRunLocalTests", function()
+      Sf.run_local_tests()
+    end, {})
+
     vim.api.nvim_create_user_command("SfOpenTestSelect", function()
       Sf.open_test_select()
     end, {})

--- a/lua/sf/init.lua
+++ b/lua/sf/init.lua
@@ -123,4 +123,7 @@ Sf.run_all_tests_in_this_file = Test.run_all_tests_in_this_file
 --- A convenient way to repeat the last executed Apex test command.
 Sf.repeat_last_tests = Test.repeat_last_tests
 
+--- Run all local tests in target_org
+Sf.run_local_tests = Test.run_local_tests
+
 return Sf

--- a/lua/sf/init.lua
+++ b/lua/sf/init.lua
@@ -36,6 +36,18 @@ Sf.save_and_push = Term.save_and_push
 --- Retrieve the file in the current buffer from target_org.
 Sf.retrieve = Term.retrieve
 
+--- Retrieve the file in the current buffer as a manifest from target_org
+Sf.retrieve_package = Term.retrieve_package
+
+--- Run the file in the current buffer as anonymous apex in target_org
+Sf.run_anonymous = Term.run_anonymous
+
+--- Run the query defined in current buffer in target_org
+Sf.run_query = Term.run_query
+
+--- Run the tooling API query defined in the current buffer in target_org
+Sf.run_tooling_query = Term.run_tooling_query
+
 --- Terminate the running command in SFTerm.
 Sf.cancel = Term.cancel
 

--- a/lua/sf/term.lua
+++ b/lua/sf/term.lua
@@ -23,6 +23,26 @@ function Term.retrieve()
   t:run(cmd)
 end
 
+function Term.retrieve_package()
+     local cmd = vim.fn.expandcmd("sf project retrieve start -x %:p -o ") .. U.get()
+     t:run(cmd)
+end
+
+function Term.run_anonymous()
+     local cmd = vim.fn.expandcmd("sf apex run -f %:p -o ") .. U.get()
+     t:run(cmd)
+end
+
+function Term.run_query()
+     local cmd = vim.fn.expandcmd("sf data query -w 5 -f %:p -o ") .. U.get()
+     t:run(cmd)
+end
+
+function Term.run_tooling_query()
+     local cmd = vim.fn.expandcmd("sf data query -t -w 5 -f %:p -o ") .. U.get()
+     t:run(cmd)
+end
+
 function Term.cancel()
   t.is_running = false -- set the flag to stop the running task
   t:run('\3')

--- a/lua/sf/test.lua
+++ b/lua/sf/test.lua
@@ -42,6 +42,11 @@ Test.repeat_last_tests = function()
   T.run(U.last_tests)
 end
 
+Test.run_local_tests = function ()
+  local cmd = string.format("sf apex run test --test-level RunLocalTests --code-coverage --result-format human --wait 180 -o %s", U.get())
+  T.run(cmd)
+end
+
 -- prompt below
 
 local actions = require 'telescope.actions'


### PR DESCRIPTION
- Add new commands to Term for retrieving an entire manifest package xml file,
for running a file as anonymous apex, and for running queries in files.
- Add new command to Test to run all local tests in target org

Also creates the user commands for these.
