### PR TITLE
Feat: Add commands for creating Apex Class, and Aura/LWC bundles

### DIFF
--- a/doc/sf.txt
+++ b/doc/sf.txt
@@ -120,6 +120,11 @@ It's |Sf.pull_md_type_json| and |Sf.list_md_type_to_retrieve| in one go.
 Creates a new Apex Class using an input name or prompting the user to enter one.
 
 ------------------------------------------------------------------------------
+                                                         *Sf.create_aura_bundle*
+                           `Sf.create_aura_bundle`
+Creates a new Aura Bundle using an input name or prompting the user to enter one.
+
+------------------------------------------------------------------------------
                                                  *Sf.retrieve_apex_under_cursor*
                         `Sf.retrieve_apex_under_cursor`
 Uses the word under the cursor as Apex name to attempt to retreive from the org.

--- a/doc/sf.txt
+++ b/doc/sf.txt
@@ -115,6 +115,11 @@ Pull the list of metadata-types into a local json file, and list them in a pop-u
 It's |Sf.pull_md_type_json| and |Sf.list_md_type_to_retrieve| in one go.
 
 ------------------------------------------------------------------------------
+                                                          *Sf.create_apex_class*
+                           `Sf.create_apex_class`
+Creates a new Apex Class using an input name or prompting the user to enter one.
+
+------------------------------------------------------------------------------
                                                  *Sf.retrieve_apex_under_cursor*
                         `Sf.retrieve_apex_under_cursor`
 Uses the word under the cursor as Apex name to attempt to retreive from the org.

--- a/doc/sf.txt
+++ b/doc/sf.txt
@@ -125,6 +125,11 @@ Creates a new Apex Class using an input name or prompting the user to enter one.
 Creates a new Aura Bundle using an input name or prompting the user to enter one.
 
 ------------------------------------------------------------------------------
+                                                         *Sf.create_lwc_bundle*
+                           `Sf.create_lwc_bundle`
+Creates a new LWC Bundle using an input name or prompting the user to enter one.
+
+------------------------------------------------------------------------------
                                                  *Sf.retrieve_apex_under_cursor*
                         `Sf.retrieve_apex_under_cursor`
 Uses the word under the cursor as Apex name to attempt to retreive from the org.

--- a/lua/sf/config.lua
+++ b/lua/sf/config.lua
@@ -184,6 +184,10 @@ local init = function()
       Sf.create_aura_bundle()
     end, {})
 
+    vim.api.nvim_create_user_command("SfCreateLwcBundle", function()
+      Sf.create_lwc_bundle()
+    end, {})
+
     vim.api.nvim_create_user_command("SfToggle", function()
       Sf.toggle_term()
     end, {})

--- a/lua/sf/config.lua
+++ b/lua/sf/config.lua
@@ -176,6 +176,10 @@ local init = function()
       Sf.pull_and_list_md_type()
     end, {})
 
+    vim.api.nvim_create_user_command("SfCreateApexClass", function()
+      Sf.create_apex_class()
+    end, {})
+
     vim.api.nvim_create_user_command("SfToggle", function()
       Sf.toggle_term()
     end, {})

--- a/lua/sf/config.lua
+++ b/lua/sf/config.lua
@@ -180,6 +180,10 @@ local init = function()
       Sf.create_apex_class()
     end, {})
 
+    vim.api.nvim_create_user_command("SfCreateAuraBundle", function()
+      Sf.create_aura_bundle()
+    end, {})
+
     vim.api.nvim_create_user_command("SfToggle", function()
       Sf.toggle_term()
     end, {})

--- a/lua/sf/init.lua
+++ b/lua/sf/init.lua
@@ -95,6 +95,9 @@ Sf.pull_and_list_md_type = Metadata.pull_and_list_md_type
 --- A convenient way to quickly pull Apex into local.
 Sf.retrieve_apex_under_cursor = Metadata.retrieve_apex_under_cursor
 
+-- Creates a new Apex Class using an input name or prompting the user to enter one
+Sf.create_apex_class = Metadata.create_apex_class
+
 -- From Test module ==========================================================
 
 --- Open a top-split window to display the Apex tests in the current file.

--- a/lua/sf/init.lua
+++ b/lua/sf/init.lua
@@ -101,6 +101,9 @@ Sf.create_apex_class = Metadata.create_apex_class
 -- Creates a new Aura Bundle using an input name or prompting the user to enter one
 Sf.create_aura_bundle = Metadata.create_aura_bundle
 
+-- Creates a new LWC Bundle using an input name or prompting the user to enter one
+Sf.create_lwc_bundle = Metadata.create_lwc_bundle
+
 -- From Test module ==========================================================
 
 --- Open a top-split window to display the Apex tests in the current file.

--- a/lua/sf/init.lua
+++ b/lua/sf/init.lua
@@ -98,6 +98,9 @@ Sf.retrieve_apex_under_cursor = Metadata.retrieve_apex_under_cursor
 -- Creates a new Apex Class using an input name or prompting the user to enter one
 Sf.create_apex_class = Metadata.create_apex_class
 
+-- Creates a new Aura Bundle using an input name or prompting the user to enter one
+Sf.create_aura_bundle = Metadata.create_aura_bundle
+
 -- From Test module ==========================================================
 
 --- Open a top-split window to display the Apex tests in the current file.

--- a/lua/sf/md.lua
+++ b/lua/sf/md.lua
@@ -40,6 +40,10 @@ function Md.create_apex_class()
   H.create_apex_class()
 end
 
+function Md.create_aura_bundle()
+  H.create_aura_bundle()
+end
+
 local pickers = require "telescope.pickers"
 local finders = require "telescope.finders"
 local previewers = require 'telescope.previewers'
@@ -286,6 +290,22 @@ end
 
 H.create_apex_class = function(name)
     U.run_cb_with_input(name, "Enter Class name: ", H.generate_class)
+end
+
+H.generate_aura = function(name)
+  local cmd = string.format("sf lightning generate component --output-dir %s --name %s --type aura", U.get_sf_root() .. H.default_dir .. "/aura", name)
+  U.silent_job_call(
+    cmd,
+    nil,
+    "Something went wrong creating the Aura bundle",
+    function()
+      vim.notify("Aura bundle " .. name .. " created", vim.log.levels.INFO)
+    end
+  )
+end
+
+H.create_aura_bundle = function(name)
+    U.run_cb_with_input(name, "Enter Aura bundle name: ", H.generate_aura)
 end
 
 return Md

--- a/lua/sf/md.lua
+++ b/lua/sf/md.lua
@@ -4,6 +4,7 @@ local C = require('sf.config')
 local H = {}
 
 H.md_folder_name = '/md'
+H.default_dir = '/force-app/main/default'
 
 local Md = {}
 
@@ -33,6 +34,10 @@ end
 
 function Md.retrieve_apex_under_cursor()
   H.retrieve_apex_under_cursor()
+end
+
+function Md.create_apex_class()
+  H.create_apex_class()
 end
 
 local pickers = require "telescope.pickers"
@@ -265,6 +270,22 @@ H.retrieve_md_type = function(type)
 
   local cmd = string.format('sf project retrieve start -m \'%s:*\' -o %s', type, U.target_org)
   T.run(cmd)
+end
+
+H.generate_class = function(name)
+  local cmd = string.format("sf apex generate class --output-dir %s --name %s", U.get_sf_root() .. H.default_dir .. "/classes", name)
+  U.silent_job_call(
+    cmd,
+    nil,
+    "Something went wrong creating the class",
+    function()
+      vim.notify("Class " .. name .. " created", vim.log.levels.INFO)
+    end
+  )
+end
+
+H.create_apex_class = function(name)
+    U.run_cb_with_input(name, "Enter Class name: ", H.generate_class)
 end
 
 return Md

--- a/lua/sf/md.lua
+++ b/lua/sf/md.lua
@@ -44,6 +44,10 @@ function Md.create_aura_bundle()
   H.create_aura_bundle()
 end
 
+function Md.create_lwc_bundle()
+  H.create_lwc_bundle()
+end
+
 local pickers = require "telescope.pickers"
 local finders = require "telescope.finders"
 local previewers = require 'telescope.previewers'
@@ -306,6 +310,22 @@ end
 
 H.create_aura_bundle = function(name)
     U.run_cb_with_input(name, "Enter Aura bundle name: ", H.generate_aura)
+end
+
+H.generate_lwc = function(name)
+  local cmd = string.format("sf lightning generate component --output-dir %s --name %s --type lwc", U.get_sf_root() .. H.default_dir .. "/lwc", name)
+  U.silent_job_call(
+    cmd,
+    nil,
+    "Something went wrong creating the LWC bundle",
+    function()
+      vim.notify("LWC bundle " .. name .. " created", vim.log.levels.INFO)
+    end
+  )
+end
+
+H.create_lwc_bundle = function(name)
+    U.run_cb_with_input(name, "Enter LWC bundle name: ", H.generate_lwc)
 end
 
 return Md

--- a/lua/sf/util.lua
+++ b/lua/sf/util.lua
@@ -108,4 +108,21 @@ M.copy_apex_name = function()
   vim.notify(string.format('"%s" copied.', file_name), vim.log.levels.INFO)
 end
 
+M.run_cb_with_input = function(arg, prompt, cb)
+  if arg ~= nil then
+    cb(arg)
+  else
+    vim.ui.input(
+      { prompt = prompt },
+      function(input)
+        if input ~= nil then
+          cb(input)
+        else
+          return
+        end
+      end
+    )
+  end
+end
+
 return M


### PR DESCRIPTION
This adds new commands for creating an Apex Class or an Aura/LWC bundle.

Commands use `vim.ui.input` to request the user for a name for the class/bundle if one was not provided (i.e.: by calling the command in the command prompt like `:SfCreateApexClass(<class name>)`). This is possible by creating a new helper function (`run_cb_with_input`) that is provided a callback that requires an input, and either passes an argument directly to the callback, or calls `vim.ui.input` if the argument was not provided, thus prompting the user. In case the user cancels the prompt, the entire action is canceled.

Generated classes and bundles are placed in the default project directories `force-app/main/default/(classes|aura|lwc)` and identify the project root using the preexisting `get_sf_root()`. Possible updates in the future could scan the `sfdx-project.json` file for possible `path` values to select instead of `force-app`, but I think the use case of alternatives to `force-app` are niche enough that this is a good starting point.