### PR TITLE
Feat: Adds Ability to Select Scratch Orgs as target_org

### DIFF
--- a/lua/sf/org.lua
+++ b/lua/sf/org.lua
@@ -37,10 +37,11 @@ H.set_target_org = function()
     prompt = 'Local target_org:'
   }, function(choice)
     if choice ~= nil then
-      local cmd = 'sf config set target-org ' .. choice
-      local err_msg = choice .. ' - set target_org failed! Not in a sfdx project folder?'
+      local org = string.gsub(choice, '%[S%] ', '')
+      local cmd = 'sf config set target-org ' .. org
+      local err_msg = org .. ' - set target_org failed! Not in a sfdx project folder?'
       local cb = function()
-        U.target_org = choice
+        U.target_org = org
       end
 
       U.silent_job_call(cmd, nil, err_msg, cb)
@@ -55,11 +56,12 @@ H.set_global_target_org = function()
     prompt = 'Global target_org:'
   }, function(choice)
     if choice ~= nil then
-      local cmd = 'sf config set target-org --global ' .. choice
-      local msg = 'Global target_org set: ' .. choice
-      local err_msg = string.format('Global set target_org [%s] failed!', choice)
+      local org = string.gsub(choice, '%[S%] ', '')
+      local cmd = 'sf config set target-org --global ' .. org
+      local msg = 'Global target_org set: ' .. org
+      local err_msg = string.format('Global set target_org [%s] failed!', org)
       local cb = function()
-        U.target_org = choice
+        U.target_org = org
       end
       U.silent_job_call(cmd, msg, err_msg, cb)
     end
@@ -83,7 +85,12 @@ H.store_orgs = function(data)
     if v.isDefaultUsername == true then
       U.target_org = v.alias
     end
-    table.insert(H.orgs, v.alias)
+    local alias = v.alias == nil and v.username or v.alias;
+    if v.isScratch == true then
+      table.insert(H.orgs, '[S] ' .. alias)
+    else
+      table.insert(H.orgs, alias)
+    end
   end
 
   U.is_table_empty(H.orgs)

--- a/lua/sf/org.lua
+++ b/lua/sf/org.lua
@@ -73,6 +73,11 @@ H.store_orgs = function(data)
   end
 
   local org_data = vim.json.decode(s, {}).result.nonScratchOrgs
+  local scratch_org_data = vim.json.decode(s, {}).result.scratchOrgs
+
+  for i = 1, #scratch_org_data do
+    org_data[#org_data + 1] = scratch_org_data[i]
+  end
 
   for _, v in pairs(org_data) do
     if v.isDefaultUsername == true then


### PR DESCRIPTION
Starts to address #47

@xixiaofinland Here is what I have so far. The first step to allow scratch org development is to allow the selection of scratch orgs when choosing a `target_org`. I added a indicator in order to alert the user which orgs are scratch orgs. I also handle the scenario where an org is created without an alias. In that case it uses the username instead. 

Please let me know your thoughts!

Future work:
I figure this is a good start but in my workflow I will need a push/pull all. This seems like a straightforward change but I am unsure if I should put it in this pull request or create a seperate one. Let me know your thoughts. I am very new to lua so please let me know if what I wrote is terrible 😄 