### PR TITLE
Feat: Adds Push/Pull Delta Commands

### DIFF
--- a/doc/sf.txt
+++ b/doc/sf.txt
@@ -31,9 +31,19 @@ Toggle the SFTerm float window.
 Save the file in the current buffer and push to target_org.
 
 ------------------------------------------------------------------------------
+                                                                 *Sf.push_delta*
+                               `Sf.push_delta`
+Push local changes to target_org.
+
+------------------------------------------------------------------------------
                                                                    *Sf.retrieve*
                                  `Sf.retrieve`
 Retrieve the file in the current buffer from target_org.
+
+------------------------------------------------------------------------------
+                                                            *Sf.retrieve_delta
+                                 `Sf.retrieve_delta`
+Retrieve remote changes from target_org.
 
 ------------------------------------------------------------------------------
                                                            *Sf.retrieve_package*

--- a/lua/sf/config.lua
+++ b/lua/sf/config.lua
@@ -150,8 +150,16 @@ local init = function()
       Sf.save_and_push()
     end, {})
 
+    vim.api.nvim_create_user_command("SFPushDelta", function()
+      Sf.push_delta()
+    end, {})
+
     vim.api.nvim_create_user_command("SFRetrieve", function()
       Sf.retrieve()
+    end, {})
+
+    vim.api.nvim_create_user_command("SFRetrieveDelta", function()
+      Sf.retrieve_delta()
     end, {})
 
     vim.api.nvim_create_user_command("SFRetrievePackage", function()

--- a/lua/sf/init.lua
+++ b/lua/sf/init.lua
@@ -33,8 +33,14 @@ Sf.toggle_term = Term.toggle
 --- Save the file in the current buffer and push to target_org.
 Sf.save_and_push = Term.save_and_push
 
+--- Push local changes to target_org.
+Sf.push_delta = Term.push_delta
+
 --- Retrieve the file in the current buffer from target_org.
 Sf.retrieve = Term.retrieve
+
+--- Retrieve remote changes from target_org.
+Sf.retrieve_delta = Term.retrieve_delta
 
 --- Retrieve the file in the current buffer as a manifest from target_org
 Sf.retrieve_package = Term.retrieve_package

--- a/lua/sf/term.lua
+++ b/lua/sf/term.lua
@@ -18,8 +18,18 @@ function Term.save_and_push()
   t:run(cmd)
 end
 
+function Term.push_delta()
+  local cmd = vim.fn.expandcmd('sf project deploy start -o ') .. U.get()
+  t:run(cmd)
+end
+
 function Term.retrieve()
   local cmd = vim.fn.expandcmd('sf project retrieve start -d %:p -o ') .. U.get()
+  t:run(cmd)
+end
+
+function Term.retrieve_delta()
+  local cmd = vim.fn.expandcmd('sf project retrieve start -o ') .. U.get()
   t:run(cmd)
 end
 


### PR DESCRIPTION
Addresses #53 

Adds commands `push_delta` and `retrieve_delta`.

`push_delta`: Runs the sf command `sf project deploy start` without specifying a specific file to deploy. 

`retrieve_delta`: Runs the sf command `sf project retrieve start` without specifying a specific file to retrieve.

If source tracking is enabled in the org then these command will only deploy/retrieve the delta. If source tracking is not enabled then calling this command will deploy/retrieve all files.

Updates documentation with new commands.

I did not add any default keybindings to this pull request. If you want to add them I was thinking something like this.
```
 vim.keymap.set('n', '<leader>sR', sf.retrieve_delta, { desc = '[R]etrieve Remote Changes from target_org' })
 vim.keymap.set('n', '<leader>sP', sf.push_delta, { desc = '[P]Push Local Changes to target_org' })
```

Let me know your thoughts!