### PR TITLE
feat: add sf.nvim as notify title to clearly show which plugin generates a message

### DIFF
--- a/lua/sf/util.lua
+++ b/lua/sf/util.lua
@@ -8,15 +8,15 @@ M.last_tests = ''
 M.target_org = ''
 
 M.show = function(msg)
-  vim.notify(msg, vim.log.levels.INFO)
+  vim.notify(msg, vim.log.levels.INFO, { title = 'sf.nvim' })
 end
 
 M.show_err = function(msg)
-  vim.notify(msg, vim.log.levels.ERROR)
+  vim.notify(msg, vim.log.levels.ERROR, { title = 'sf.nvim' })
 end
 
 M.show_warn = function(msg)
-  vim.notify(msg, vim.log.levels.WARN)
+  vim.notify(msg, vim.log.levels.WARN, { title = 'sf.nvim' })
 end
 
 M.get = function()


### PR DESCRIPTION
Just thought it'd be nice to have `vim.notify` clearly show that `sf.nvim` shows a particular message.

Since we usually use notify for all notifications, making this kind of visual distinction might be helpful.

Appreciate the review!