### PR TITLE
feat: add sf-org-open commands (+ open current file)

### DIFF
--- a/lua/sf/config.lua
+++ b/lua/sf/config.lua
@@ -280,6 +280,8 @@ local init = function()
     nmap('<leader>s-', Sf.go_to_sf_root, "cd into root")
     nmap('<leader>ct', Sf.create_ctags, 'create ctag file in project root')
     nmap('<leader>ft', Sf.create_and_list_ctags, 'fzf list updated ctags')
+    nmap("<leader>so", Sf.org_open, "open current org in browser")
+    nmap("<leader>sO", Sf.org_open_current_file, "open current file in browser")
 
     -- Hotkeys for metadata files only;
     if vim.tbl_contains(Cfg.config.hotkeys_in_filetypes, vim.bo.filetype) then

--- a/lua/sf/init.lua
+++ b/lua/sf/init.lua
@@ -28,12 +28,6 @@ Sf.copy_apex_name = Util.copy_apex_name
 
 -- From Term module ==========================================================
 
---- Open the current org in browser
-Sf.org_open = Term.org_open
-
---- Open the current file in browser
-Sf.org_open_current_file = Term.org_open_current_file
-
 --- Toggle the SFTerm float window.
 Sf.toggle_term = Term.toggle
 
@@ -94,6 +88,12 @@ Sf.diff_in_target_org = Org.diff_in_target_org
 --- Similar to |Sf.diff_in_target_org|, you can choose which org to diff with.
 --- The left window displays the org verison, the right window displays the local verison.
 Sf.diff_in_org = Org.diff_in_org
+
+--- Open the current org in browser
+Sf.org_open = Org.open
+
+--- Open the current file in browser
+Sf.org_open_current_file = Org.open_current_file
 
 -- From Metadata module ==========================================================
 

--- a/lua/sf/init.lua
+++ b/lua/sf/init.lua
@@ -28,6 +28,12 @@ Sf.copy_apex_name = Util.copy_apex_name
 
 -- From Term module ==========================================================
 
+--- Open the current org in browser
+Sf.org_open = Term.org_open
+
+--- Open the current file in browser
+Sf.org_open_current_file = Term.org_open_current_file
+
 --- Toggle the SFTerm float window.
 Sf.toggle_term = Term.toggle
 

--- a/lua/sf/org.lua
+++ b/lua/sf/org.lua
@@ -23,12 +23,32 @@ function Org.diff_in_org()
   H.diff_in_org()
 end
 
+function Org.open()
+  H.open()
+end
+
+function Org.open_current_file()
+  H.open_current_file()
+end
+
 local api = vim.api
 
 H.orgs = {}
 
 H.clean_org_cache = function()
   H.orgs = {}
+end
+
+H.open = function()
+	local cmd = 'sf org open'
+  local err_msg = org .. ' - open command failed!'
+	U.silent_job_call(cmd, nil, err_msg, nil)
+end
+
+H.open_current_file = function() 
+	local cmd 'sf org open --source-file "%:p"'
+  local err_msg = org .. ' - open command failed for the current file!'
+	U.silent_job_call(cmd, nil, err_msg, nil)
 end
 
 H.set_target_org = function()

--- a/lua/sf/org.lua
+++ b/lua/sf/org.lua
@@ -43,14 +43,14 @@ end
 
 H.open = function()
   local org = string.gsub(choice, '%[S%] ', '')
-  local cmd = 'sf org open'
+  local cmd = 'sf org open -o' .. U.get()
   local err_msg = org .. ' - open command failed!'
   U.silent_job_call(cmd, nil, err_msg, nil)
 end
 
 H.open_current_file = function()
   local org = string.gsub(choice, '%[S%] ', '')
-  local cmd = 'sf org open --source-file "%:p"'
+  local cmd = 'sf org open --source-file "%:p" -o' .. U.get()
   local err_msg = org .. ' - open command failed for the current file!'
   U.silent_job_call(cmd, nil, err_msg, nil)
 end

--- a/lua/sf/org.lua
+++ b/lua/sf/org.lua
@@ -42,12 +42,14 @@ H.clean_org_cache = function()
 end
 
 H.open = function()
+  local org = string.gsub(choice, '%[S%] ', '')
   local cmd = 'sf org open'
   local err_msg = org .. ' - open command failed!'
   U.silent_job_call(cmd, nil, err_msg, nil)
 end
 
-H.open_current_file = function() 
+H.open_current_file = function()
+  local org = string.gsub(choice, '%[S%] ', '')
   local cmd = 'sf org open --source-file "%:p"'
   local err_msg = org .. ' - open command failed for the current file!'
   U.silent_job_call(cmd, nil, err_msg, nil)

--- a/lua/sf/org.lua
+++ b/lua/sf/org.lua
@@ -42,15 +42,15 @@ H.clean_org_cache = function()
 end
 
 H.open = function()
-	local cmd = 'sf org open'
+  local cmd = 'sf org open'
   local err_msg = org .. ' - open command failed!'
-	U.silent_job_call(cmd, nil, err_msg, nil)
+  U.silent_job_call(cmd, nil, err_msg, nil)
 end
 
 H.open_current_file = function() 
-	local cmd 'sf org open --source-file "%:p"'
+  local cmd = 'sf org open --source-file "%:p"'
   local err_msg = org .. ' - open command failed for the current file!'
-	U.silent_job_call(cmd, nil, err_msg, nil)
+  U.silent_job_call(cmd, nil, err_msg, nil)
 end
 
 H.set_target_org = function()

--- a/lua/sf/term.lua
+++ b/lua/sf/term.lua
@@ -17,16 +17,6 @@ function Term.open()
   t:open()
 end
 
-function Term.org_open()
-	local cmd = vim.fn.expandcmd('sf org open')
-	t:run(cmd)
-end
-
-function Term.org_open_current_file()
-	local cmd = vim.fn.expandcmd('sf org open --source-file "%:p"')
-	t:run(cmd)
-end
-
 function Term.save_and_push()
   -- vim.api.nvim_command('e') -- reload file to avoid invoking y/n pop-up in Ex
   vim.api.nvim_command('write!')

--- a/lua/sf/term.lua
+++ b/lua/sf/term.lua
@@ -17,6 +17,16 @@ function Term.open()
   t:open()
 end
 
+function Term.org_open()
+	local cmd = vim.fn.expandcmd('sf org open')
+	t:run(cmd)
+end
+
+function Term.org_open_current_file()
+	local cmd = vim.fn.expandcmd('sf org open --source-file "%:p"')
+	t:run(cmd)
+end
+
 function Term.save_and_push()
   -- vim.api.nvim_command('e') -- reload file to avoid invoking y/n pop-up in Ex
   vim.api.nvim_command('write!')


### PR DESCRIPTION
I added `sf org open` with the option to open the org, as well as the current file (e.g. flow)

This does not perform a lot of validation, though, so it's the user's responsibility to make sure they can use `sf org --source-file ...` properly.

Happy to hear some thoughts!