### PR TITLE
Fix issues with create lwc command, and extra org flag

### DIFF
--- a/lua/sf/md.lua
+++ b/lua/sf/md.lua
@@ -233,7 +233,7 @@ end
 ---@param name string
 H.generate_lwc = function(name)
   -- local cmd = string.format("sf lightning generate component --output-dir %s --name %s --type lwc", U.get_sf_root() .. vim.g.sf.default_dir .. "/lwc", name)
-  local cmd = B:new():cmd('lightning'):act('generate component'):addParams({ ["-d"] = U.get_default_dir_path() .. '/lwc', ['-n'] = name, ['--type'] = 'lwc' })
+  local cmd = B:new():cmd('lightning'):act('generate component'):addParams({ ["-d"] = U.get_default_dir_path() .. 'lwc', ['-n'] = name, ['--type'] = 'lwc' }):makeLocal():build()
   U.silent_job_call(
     cmd,
     nil,

--- a/lua/sf/sub/cmd_builder.lua
+++ b/lua/sf/sub/cmd_builder.lua
@@ -21,6 +21,7 @@ function CommandBuilder:new(base_command)
         params = {},
         param_str = "",
         org = U.target_org or nil,
+        require_org = true,
     }, CommandBuilder)
     return obj
 end
@@ -38,6 +39,13 @@ end
 ---@return CommandBuilder
 function CommandBuilder:act(action)
     self.action = action
+    return self
+end
+
+---Make the command local only
+---@return CommandBuilder
+function CommandBuilder:makeLocal()
+    self.require_org = false
     return self
 end
 
@@ -140,8 +148,10 @@ function CommandBuilder:build()
         cmd = cmd .. ' ' .. self.param_str
     end
 
-    local org_param = string.format('-o "%s"', self.org)
-    cmd = cmd .. " " .. org_param
+    if self.require_org then
+      local org_param = string.format('-o "%s"', self.org)
+      cmd = cmd .. " " .. org_param
+    end
 
     return cmd
 end


### PR DESCRIPTION
Create lwc command was failing due to:
- Missing  `build()`
- Extra slash in directory prepending lwc
- Extra org flag when the command is only local and does not take an org.

This PR attempts to solve this by:
- Adding the missing `build()` command
- Removing the extra slash
- Creating a `makeLocal()` function on the `CommandBuilder` object that toggles a new flag prompting the org parameter not to be added when building the command. This is added in a way so that existing commands are not affected.

PS: Hey @xixiaofinland ! I'm back! Been really absent with moving and just **tons** of work. I see you've done so many improvements on this, it's awesome! I hope I can contribue a bit more now