### PR TITLE
fix: fix open file in org command in help

### DIFF
--- a/lua/sf/init.lua
+++ b/lua/sf/init.lua
@@ -100,7 +100,6 @@ Sf.diff_in_org = Org.diff_in_org
 Sf.org_open = Org.open
 
 --- Open the current file in the target_org in browser
-
 Sf.org_open_current_file = Org.open_current_file
 
 -- From Metadata module ==========================================================


### PR DESCRIPTION
There's an extra line in help between the Sf.org_open_current_file and its comment, causing the command not to show properly in help:
![image](https://github.com/user-attachments/assets/93beb939-731b-48c3-b882-c913d131031b)


This removes the extra line
