### PR TITLE
chore: add empty org guard to md pull

### DIFF
--- a/lua/sf/md.lua
+++ b/lua/sf/md.lua
@@ -111,6 +111,9 @@ end
 end
 
 H.pull_md_json = function()
+  if U.is_empty_str(U.target_org) then
+    return U.show_err('Target_org empty!')
+  end
   local md_types = vim.g.sf.types_to_retrieve
   for _, type in pairs(md_types) do
     H.pull_metadata(type)


### PR DESCRIPTION
Other commands that pull or list md check for an empty org once at the beginning. The `pull_md_json` command goes directly into looping, and then checks inside each loop, causing an error message to be created for each md type in the list.

Adding a guard at the top ensures a single message is shown and the loop is not even attempted.