### PR TITLE
feat: change print to vim.notify

### DIFF
--- a/lua/sf/util.lua
+++ b/lua/sf/util.lua
@@ -124,7 +124,7 @@ M.silent_job_call = function(cmd, msg, err_msg, cb)
     on_exit =
         function(_, code)
           if code == 0 and msg ~= nil then
-            print(msg)
+            vim.notify(msg, vim.log.levels.INFO)
           elseif code ~= 0 and err_msg ~= nil then
             vim.notify(err_msg, vim.log.levels.ERROR)
           end


### PR DESCRIPTION
Most of the plugin uses `vim.notify` to report information/errors/warnings to the user, but there's a single `print` used throughout, just used in the pull of md. This changes the print statement to also use `vim.notify` with `INFO` level, the same as other functionalities.