### PR TITLE
chore: sanitize paths

### DIFF
--- a/lua/sf/md.lua
+++ b/lua/sf/md.lua
@@ -126,7 +126,7 @@ H.pull_metadata = function(type)
 
   U.create_plugin_folder_if_not_exist()
 
-  local md_file = string.format('%s/%s_%s.json', U.get_plugin_folder_path(), type, U.target_org)
+  local md_file = string.format('%s%s_%s.json', U.get_plugin_folder_path(), type, U.target_org)
 
   -- local cmd = string.format('sf org list metadata -m %s -o %s -f %s', type, U.target_org, md_file)
   local cmd = B:new():cmd('org'):act('list metadata'):addParams({ ["-m"] = type, ["-f"] = md_file }):build()
@@ -143,7 +143,7 @@ H.pull_md_type_json = function()
 
   U.create_plugin_folder_if_not_exist()
 
-  local metadata_types_file = string.format('%s/%s.json', U.get_plugin_folder_path(), 'metadata-types')
+  local metadata_types_file = string.format('%s%s.json', U.get_plugin_folder_path(), 'metadata-types')
   -- local cmd = string.format('sf org list metadata-types -o %s -f %s', U.target_org, metadata_types_file)
   local cmd = B:new():cmd('org'):act('list metadata-types'):addParams('-f', metadata_types_file):build()
   local msg = 'Metadata-type file retrieved'
@@ -216,7 +216,7 @@ end
 ---@param name string
 H.generate_aura = function(name)
   -- local cmd = string.format("sf lightning generate component --output-dir %s --name %s --type aura", U.get_default_dir_path() .. "/aura", name)
-  local cmd = B:new():cmd('lightning'):act('generate component'):addParams({ ["-d"] = U.get_default_dir_path() .. '/aura', ['-n'] = name, ['--type'] = 'aura' }):localOnly():build()
+  local cmd = B:new():cmd('lightning'):act('generate component'):addParams({ ["-d"] = U.get_default_dir_path() .. 'aura', ['-n'] = name, ['--type'] = 'aura' }):localOnly():build()
   U.silent_job_call(
     cmd,
     nil,

--- a/lua/sf/org.lua
+++ b/lua/sf/org.lua
@@ -228,14 +228,17 @@ H.find_file = function(path, target)
   -- if scanner is nil, then path is not a valid dir
   if scanner then
     local file, type = vim.loop.fs_scandir_next(scanner)
+    if (path:sub(-1) ~= "/") then
+      path = path .. "/"
+    end
     while file do
       if type == "directory" then
-        local found = H.find_file(path .. "/" .. file, target)
+        local found = H.find_file(path .. file, target)
         if found then
           return found
         end
       elseif file == target then
-        return path .. "/" .. file
+        return path .. file
       end
       -- get the next file and type
       file, type = vim.loop.fs_scandir_next(scanner)

--- a/lua/sf/util.lua
+++ b/lua/sf/util.lua
@@ -34,7 +34,14 @@ M.get = function()
 end
 
 M.get_default_dir_path = function()
-  return M.get_sf_root() .. vim.g.sf.default_dir
+  local dir_path = M.get_sf_root() .. vim.g.sf.default_dir
+    if (dir_path:sub(1,1) ~= "/") then
+        dir_path = "/" .. dir_path
+    end
+    if (dir_path:sub(-1) ~= "/") then
+        dir_path = dir_path .. "/"
+    end
+  return dir_path
 end
 
 M.get_apex_folder_path = function()
@@ -42,7 +49,14 @@ M.get_apex_folder_path = function()
 end
 
 M.get_plugin_folder_path = function()
-  return M.get_sf_root() .. vim.g.sf.plugin_folder_name
+    local folder_path = M.get_sf_root() .. vim.g.sf.plugin_folder_name
+    if (folder_path:sub(1,1) ~= "/") then
+        folder_path = "/" .. folder_path
+    end
+    if (folder_path:sub(-1) ~= "/") then
+        folder_path = folder_path .. "/"
+    end
+  return folder_path
 end
 
 M.create_plugin_folder_if_not_exist = function()


### PR DESCRIPTION
Most commands assume the paths for the plugin dir and default project dir will be prepended and appended with slashes. This adds extra checks to add the slashes if they have not been added in the setup config, thus preventing wrongly concatenating a path with a filename due to user error.

It also applies the same logic to the `find_file` function, so an extra slash is not added by mistake.

Finally, it removes extra slashes which were duplicates since the commands already assumed a slash in that place.