### PR TITLE
feat: add support to run jest tests

### DIFF
--- a/lua/sf/init.lua
+++ b/lua/sf/init.lua
@@ -156,6 +156,12 @@ Sf.repeat_last_tests = Test.repeat_last_tests
 --- Run all local tests in target_org
 Sf.run_local_tests = Test.run_local_tests
 
+--- Run all jest tests in project
+Sf.run_all_jests = Test.run_all_jests
+
+--- Run all jest tests in current file
+Sf.run_jest_file = Test.run_jest_file
+
 --- show sign icons to indicates uncovered lines from the latest test running result.
 Sf.toggle_sign = Test.toggle_sign
 

--- a/lua/sf/test.lua
+++ b/lua/sf/test.lua
@@ -106,6 +106,18 @@ Test.run_local_tests = function()
   T.run(cmd)
 end
 
+Test.run_all_jests = function()
+    T.run('npm run test:unit:coverage')
+end
+
+Test.run_jest_file = function()
+    if vim.fn.expand('%'):match('(.*)%.test%.js$') == nil then
+        vim.notify('Not in a jest test file', vim.log.levels.ERROR)
+        return
+    end
+    T.run(string.format('npm run test:unit -- -- %s', vim.fn.expand('%')))
+end
+
 -- helper;
 
 H.validateInTestClass = function()


### PR DESCRIPTION
Jest tests are not as commonly used for LWCs, just because they're not required, but they're heavily recommended by Salesforce. VSCode has some functionality to run jests, though more in depth debugging and such require other plugins.

This offers a very basic functionality to get us started on offering jest runs, by simply exposing the two more common commands to run jests in the `sf` terminal.

There's lots of room for improvement on this (e.g.: use treesitter to run a single command), but I think this gets out off the start line.