### PR TITLE
chore: further sanitize paths

### DIFF
--- a/lua/sf/util.lua
+++ b/lua/sf/util.lua
@@ -35,7 +35,7 @@ end
 
 M.get_default_dir_path = function()
   local dir_path = M.get_sf_root() .. vim.g.sf.default_dir
-    if (dir_path:sub(1,1) ~= "/") then
+    if (dir_path:sub(1,1) ~= "/" and dir_path:sub(1,1) ~= ".") then
         dir_path = "/" .. dir_path
     end
     if (dir_path:sub(-1) ~= "/") then
@@ -50,7 +50,7 @@ end
 
 M.get_plugin_folder_path = function()
     local folder_path = M.get_sf_root() .. vim.g.sf.plugin_folder_name
-    if (folder_path:sub(1,1) ~= "/") then
+    if (folder_path:sub(1,1) ~= "/" and folder_path:sub(1,1) ~= ".") then
         folder_path = "/" .. folder_path
     end
     if (folder_path:sub(-1) ~= "/") then
@@ -87,6 +87,10 @@ M.get_sf_root = function()
 
   if root == nil then
     error('File not in a sf project folder')
+  end
+
+  if root:sub(-1) ~= "/" then
+    root = root .. "/"
   end
 
   return root


### PR DESCRIPTION
This PR extends on the recent one to sanitize paths using checks for "/" in dir names by:
- Ensuring `get_sf_root()` always returns a dir name with an appended "/"
- Ensuring checks where a "/" was appended do not append one if the dir is `.`

For some reason, even though for me `get_sf_root()` returned an absolute path, when used in `get_plugin_folder_path()` it was interpreted as ".", causing the md files not to be found when trying to list md.