### PR TITLE
feat: list and download logs

### DIFF
--- a/lua/sf/init.lua
+++ b/lua/sf/init.lua
@@ -102,6 +102,9 @@ Sf.org_open = Org.open
 --- Open the current file in the target_org in browser
 Sf.org_open_current_file = Org.open_current_file
 
+--- Get a list of logs from the org, and choose one to download and open
+Sf.pull_logs = Org.pull_logs
+
 -- From Metadata module ==========================================================
 
 --- Download metadata name list, e.g. Apex names, LWC names, StaticResource names, etc. as Json files into the the project root path "md" folder.

--- a/lua/sf/init.lua
+++ b/lua/sf/init.lua
@@ -103,7 +103,7 @@ Sf.org_open = Org.open
 Sf.org_open_current_file = Org.open_current_file
 
 --- Get a list of logs from the org, and choose one to download and open
-Sf.pull_logs = Org.pull_logs
+Sf.pull_log = Org.pull_log
 
 -- From Metadata module ==========================================================
 

--- a/lua/sf/org.lua
+++ b/lua/sf/org.lua
@@ -38,13 +38,13 @@ function Org.open_current_file()
   U.job_call(cmd, nil, err_msg)
 end
 
-function Org.pull_logs()
-    H.pull_logs()
+function Org.pull_log()
+    H.pull_log()
 end
 
 -- helpers;
 
-H.pull_logs = function()
+H.pull_log = function()
     if U.is_empty_str(U.target_org) then
         return U.show_err('Target_org empty!')
     end

--- a/lua/sf/org.lua
+++ b/lua/sf/org.lua
@@ -74,6 +74,11 @@ H.pull_log = function()
 
         local logs = {}
         local log_names = {}
+
+        if #log_table["result"] == 0 then
+            return U.show_warn('No logs found in org')
+        end
+
         for _, v in ipairs(log_table["result"]) do
             local name = string.format('%s | %s | %s bytes | %s', v["LogUser"]["Name"], string.gsub(v["StartTime"], "T", " "), v["LogLength"], v["Status"])
             table.insert(log_names, name)

--- a/lua/sf/org.lua
+++ b/lua/sf/org.lua
@@ -38,7 +38,19 @@ function Org.open_current_file()
   U.job_call(cmd, nil, err_msg)
 end
 
+function Org.pull_logs()
+    H.pull_logs()
+end
+
 -- helpers;
+
+H.pull_logs = function()
+    if U.is_empty_str(U.target_org) then
+        return U.show_err('Target_org empty!')
+    end
+
+    U.show('Querying logs...')
+end
 
 H.orgs = {}
 

--- a/lua/sf/org.lua
+++ b/lua/sf/org.lua
@@ -48,10 +48,21 @@ H.pull_log = function()
     if U.is_empty_str(U.target_org) then
         return U.show_err('Target_org empty!')
     end
+    if not U.is_installed('fzf-lua') then
+      return U.show_err('fzf-lua is not installed. Need it to show the list.')
+    end
 
     U.show('Querying logs...')
+    local log_id
+    local on_pull = function(obj)
+        if obj.code ~= 0 then
+            return U.show_err('Failed to download log from org')
+        end
 
-    local on_exit = function (obj)
+        U.try_open_file(U.get_plugin_folder_path() .. "logs/" .. log_id .. ".log")
+    end
+
+    local on_list = function (obj)
         if obj.code ~= 0 then
             return U.show_err('Failed to get logs from org')
         end
@@ -72,24 +83,34 @@ H.pull_log = function()
             logs[name] = v
         end
 
-        require('fzf-lua').fzf_exec(log_names, {fzf_opts = {
-            ['--preview-window'] = 'nohidden,down,50%',
-            ['--preview'] = function(items)
-                local contents = {}
-                local prepend_char = ""
-                vim.tbl_map(
-                    function(x)
-                        table.insert(contents, prepend_char .. U.table_to_string_lines(logs[x])) 
-                        prepend_char = "\n"
+        require('fzf-lua').fzf_exec(log_names, {
+            fzf_opts = {
+                ['--preview-window'] = 'nohidden,down,50%',
+                ['--preview'] = function(items)
+                    local contents = {}
+                    local prepend_char = ""
+                    vim.tbl_map(
+                            function(x)
+                            table.insert(contents, prepend_char .. U.table_to_string_lines(logs[x]))
+                            prepend_char = "\n"
+                        end
+                    , items)
+                    return contents
                     end
-                , items)
-                return contents
+            },
+            actions = {
+                ['default'] = function(selected)
+                    log_id = logs[selected[1]]["Id"]
+                    U.show('Downloading log...')
+                    local get_cmd = B:new():cmd('apex'):act('get'):subact('log'):addParams("-i", log_id):addParams("-d", U.get_plugin_folder_path() .. "logs/"):buildAsTable()
+                    vim.system(get_cmd, {}, vim.schedule_wrap(on_pull))
                 end
-        }})
+            }
+            })
     end
 
     local cmd_tbl = B:new():cmd('apex'):act('list'):subact('log'):addParams('--json'):buildAsTable()
-    vim.system(cmd_tbl, {}, vim.schedule_wrap(on_exit))
+    vim.system(cmd_tbl, {}, vim.schedule_wrap(on_list))
 end
 
 H.orgs = {}

--- a/lua/sf/sub/cmd_builder.lua
+++ b/lua/sf/sub/cmd_builder.lua
@@ -167,7 +167,6 @@ function CommandBuilder:build()
     end
     cmd = cmd .. " " .. table.concat(param_strings, " ")
   end
-  cmd = cmd .. " " .. table.concat(param_strings, " ")
 
   if not U.is_empty_str(self.param_str) then
     cmd = cmd .. " " .. self.param_str

--- a/lua/sf/sub/cmd_builder.lua
+++ b/lua/sf/sub/cmd_builder.lua
@@ -15,17 +15,17 @@ CommandBuilder.__index = CommandBuilder
 ---@param base_command string|nil
 ---@return CommandBuilder
 function CommandBuilder:new(base_command)
-    local obj = setmetatable({
-        base_cmd = base_command or "sf",
-        command = "",
-        action = "",
-        subactions = {},
-        params = {},
-        param_str = "",
-        org = U.target_org or nil,
-        require_org = true,
-    }, CommandBuilder)
-    return obj
+  local obj = setmetatable({
+    base_cmd = base_command or "sf",
+    command = "",
+    action = "",
+    subactions = {},
+    params = {},
+    param_str = "",
+    org = U.target_org or nil,
+    require_org = true,
+  }, CommandBuilder)
+  return obj
 end
 
 ---Set the command
@@ -48,8 +48,8 @@ end
 ---@param subaction string
 ---@return CommandBuilder
 function CommandBuilder:subact(subaction)
-    table.insert(self.subactions, subaction)
-    return self
+  table.insert(self.subactions, subaction)
+  return self
 end
 
 ---Make the command local only
@@ -139,37 +139,35 @@ end
 ---Build the final command string
 ---@return string
 function CommandBuilder:build()
-    self:validate()
+  self:validate()
 
-    local cmd = string.format('%s %s %s',
-        self.base_cmd, self.command, self.action)
+  local cmd = string.format("%s %s %s", self.base_cmd, self.command, self.action)
 
-    if #self.subactions > 0 then
-        local subact_string = ""
-        for _, subaction in ipairs(self.subactions) do
-            subact_string = subact_string .. " " .. subaction
-        end
-
-        if subact_string ~= "" then
-            cmd = cmd .. " " .. subact_string
-        end
+  if #self.subactions > 0 then
+    local subact_string = ""
+    for _, subaction in ipairs(self.subactions) do
+      subact_string = subact_string .. " " .. subaction
     end
 
-    local sortedParams = self:sortParams()
-    if #sortedParams > 0 then
-        local param_strings = {}
-        for _, param in ipairs(sortedParams) do
-            if param.value == "" then
-                table.insert(param_strings, param.flag)
-            else
-                local expanded_value = string.format('"%s"', vim.fn.expandcmd(param.value))
-                table.insert(param_strings, param.flag .. " " .. expanded_value)
-            end
-        end
-        cmd = cmd .. " " .. table.concat(param_strings, " ")
+    if subact_string ~= "" then
+      cmd = cmd .. " " .. subact_string
+    end
+  end
+
+  local sortedParams = self:sortParams()
+  if #sortedParams > 0 then
+    local param_strings = {}
+    for _, param in ipairs(sortedParams) do
+      if param.value == "" then
+        table.insert(param_strings, param.flag)
+      else
+        local expanded_value = string.format('"%s"', vim.fn.expandcmd(param.value))
+        table.insert(param_strings, param.flag .. " " .. expanded_value)
+      end
     end
     cmd = cmd .. " " .. table.concat(param_strings, " ")
   end
+  cmd = cmd .. " " .. table.concat(param_strings, " ")
 
   if not U.is_empty_str(self.param_str) then
     cmd = cmd .. " " .. self.param_str
@@ -186,33 +184,33 @@ end
 ---Build the final command as a string table
 ---@return table
 function CommandBuilder:buildAsTable()
-    self:validate()
+  self:validate()
 
-    local cmd_tbl = {self.base_cmd, self.command, self.action}
+  local cmd_tbl = { self.base_cmd, self.command, self.action }
 
-    if #self.subactions > 0 then
-        for _, subaction in ipairs(self.subactions) do
-            table.insert(cmd_tbl, subaction)
-        end
+  if #self.subactions > 0 then
+    for _, subaction in ipairs(self.subactions) do
+      table.insert(cmd_tbl, subaction)
     end
+  end
 
-    local sortedParams = self:sortParams()
-    if #sortedParams > 0 then
-        for _, param in ipairs(sortedParams) do
-            table.insert(cmd_tbl, param.flag)
-            if param.value ~= "" then
-                local expanded_value = string.format('%s', vim.fn.expandcmd(param.value))
-                table.insert(cmd_tbl, expanded_value)
-            end
-        end
+  local sortedParams = self:sortParams()
+  if #sortedParams > 0 then
+    for _, param in ipairs(sortedParams) do
+      table.insert(cmd_tbl, param.flag)
+      if param.value ~= "" then
+        local expanded_value = string.format("%s", vim.fn.expandcmd(param.value))
+        table.insert(cmd_tbl, expanded_value)
+      end
     end
+  end
 
-    if self.require_org then
-      table.insert(cmd_tbl, '-o')
-      table.insert(cmd_tbl, self.org)
-    end
+  if self.require_org then
+    table.insert(cmd_tbl, "-o")
+    table.insert(cmd_tbl, self.org)
+  end
 
-    return cmd_tbl
+  return cmd_tbl
 end
 
 function CommandBuilder:t()

--- a/lua/sf/sub/cmd_builder.lua
+++ b/lua/sf/sub/cmd_builder.lua
@@ -156,6 +156,32 @@ function CommandBuilder:build()
     return cmd
 end
 
+---Build the final command as a string table
+---@return table
+function CommandBuilder:buildAsTable()
+    self:validate()
+
+    local cmd_tbl = {self.base_cmd, self.command, self.action}
+
+    local sortedParams = self:sortParams()
+    if #sortedParams > 0 then
+        for _, param in ipairs(sortedParams) do
+            table.insert(cmd_tbl, param.flag)
+            if param.value ~= "" then
+                local expanded_value = string.format('"%s"', vim.fn.expandcmd(param.value))
+                table.insert(cmd_tbl, expanded_value)
+            end
+        end
+    end
+
+    if self.require_org then
+      table.insert(cmd_tbl, '-o')
+      table.insert(cmd_tbl, self.org)
+    end
+
+    return cmd_tbl
+end
+
 function CommandBuilder:t()
     local t = "%:p"
     return vim.fn.expandcmd(t)

--- a/lua/sf/sub/cmd_builder.lua
+++ b/lua/sf/sub/cmd_builder.lua
@@ -195,7 +195,7 @@ function CommandBuilder:buildAsTable()
         for _, param in ipairs(sortedParams) do
             table.insert(cmd_tbl, param.flag)
             if param.value ~= "" then
-                local expanded_value = string.format('"%s"', vim.fn.expandcmd(param.value))
+                local expanded_value = string.format('%s', vim.fn.expandcmd(param.value))
                 table.insert(cmd_tbl, expanded_value)
             end
         end

--- a/lua/sf/sub/cmd_builder.lua
+++ b/lua/sf/sub/cmd_builder.lua
@@ -4,6 +4,7 @@ local U = require('sf.util')
 ---@field base_cmd string
 ---@field command string
 ---@field action string
+---@field subactions table<string>
 ---@field params table<string, string>
 ---@field param_str string
 ---@field org string|nil
@@ -18,6 +19,7 @@ function CommandBuilder:new(base_command)
         base_cmd = base_command or "sf",
         command = "",
         action = "",
+        subactions = {},
         params = {},
         param_str = "",
         org = U.target_org or nil,
@@ -39,6 +41,14 @@ end
 ---@return CommandBuilder
 function CommandBuilder:act(action)
     self.action = action
+    return self
+end
+
+---Add a sub-action
+---@param subaction string
+---@return CommandBuilder
+function CommandBuilder:subact(subaction)
+    table.insert(self.subactions, subaction)
     return self
 end
 
@@ -130,6 +140,17 @@ function CommandBuilder:build()
     local cmd = string.format('%s %s %s',
         self.base_cmd, self.command, self.action)
 
+    if #self.subactions > 0 then
+        local subact_string = ""
+        for _, subaction in ipairs(self.subactions) do
+            subact_string = subact_string .. " " .. subaction
+        end
+
+        if subact_string ~= "" then
+            cmd = cmd .. " " .. subact_string
+        end
+    end
+
     local sortedParams = self:sortParams()
     if #sortedParams > 0 then
         local param_strings = {}
@@ -162,6 +183,12 @@ function CommandBuilder:buildAsTable()
     self:validate()
 
     local cmd_tbl = {self.base_cmd, self.command, self.action}
+
+    if #self.subactions > 0 then
+        for _, subaction in ipairs(self.subactions) do
+            table.insert(cmd_tbl, subaction)
+        end
+    end
 
     local sortedParams = self:sortParams()
     if #sortedParams > 0 then

--- a/lua/sf/sub/cmd_builder.lua
+++ b/lua/sf/sub/cmd_builder.lua
@@ -199,7 +199,7 @@ function CommandBuilder:buildAsTable()
     for _, param in ipairs(sortedParams) do
       table.insert(cmd_tbl, param.flag)
       if param.value ~= "" then
-        local expanded_value = string.format("%s", vim.fn.expandcmd(param.value))
+        local expanded_value = vim.fn.expandcmd(param.value)
         table.insert(cmd_tbl, expanded_value)
       end
     end

--- a/lua/sf/sub/config_user_command.lua
+++ b/lua/sf/sub/config_user_command.lua
@@ -65,6 +65,7 @@ M.sub_cmd_tbl = {
       fetchList = Sf.fetch_org_list,
       open = Sf.org_open,
       openCurrentFile = Sf.org_open_current_file,
+      pullLog = Sf.pull_log,
     },
     impl = common_impl,
     complete = function(subcmd_arg_lead)


### PR DESCRIPTION
This PR adds a new functionality to the plugin, one for listing logs in the org and downloading and opening one locally (see issue #228 )

It uses `vim.system` to perform the cli jobs, and `fzf-lua` to list the logs found, then downloading a selected log and opening it.

Because `vim.system` takes a table of strings as a command, this also adds a few extra changes into the plugin, namely:
1) Adds a new `buildAsTable()` method to `CommandBuilder`, which returns a table expression of the cli command to run
2) Adds a `subactions` table to `CommandBuilder`: `vim.system` command strings in the table cannot have spaces, otherwise the command fails. Because of this, subcommands cannot be added using `act` and spaces, as in other cases (see: create classes or components). This adds a new table of "subactions" which are then concatenated when building the command, both in the `build()` and `buildAsTable()` methods. Because the table is initialized to be empty, and subactions are only concatenated if the table is populated, this should not affect existing calls to `build()`

**Things to note:**
- Because some calls to the nvim api cannot be performed within callbacks, the call to `vim.system` requires using `vim.schedule_wrap` around the callback function.
- This shows how we could use `vim.system` to perform jobs in the background using the cli instead of `vim.fn.jobstart`, but because it requires some changes, we should approach refactoring other cases carefully
- The `buildAsTable` method expands parameter values similarly to `build`, but **removes the surrounding quotes**. These were being added to the `-i` flag value causing the cli to fail because the Id had extra quotes. I'm guessing `vim.system` already quotes values, so those may not be needed. Still, we should be careful about this when refactoring other commands
- The `fzf-lua` preview for this functionality shows a simple way in which we could remove the extra blank line at the top of the `SF md list` preview window