### PR TITLE
feat: Add cmd shortcut for run all tests

### DIFF
--- a/lua/sf/sub/config_user_command.lua
+++ b/lua/sf/sub/config_user_command.lua
@@ -87,6 +87,7 @@ M.sub_cmd_tbl = {
       currentTest = Sf.run_current_test,
       allTestsInThisFile = Sf.run_all_tests_in_this_file,
       select = Sf.open_test_select,
+      allTestsInOrg = Sf.run_local_tests
     },
     impl = common_impl,
     complete = function(subcmd_arg_lead)

--- a/lua/sf/test.lua
+++ b/lua/sf/test.lua
@@ -100,7 +100,7 @@ Test.run_local_tests = function()
     ['-c'] = '',
     ['-r'] = 'human',
     ['-w'] = 180,
-  })
+  }):build()
 
   U.last_tests = cmd
   T.run(cmd)


### PR DESCRIPTION
This PR adds a shortcut command for running all tests in the org. It also fixes a bug in the `run_local_tests` method, where the `build()` call was missing