### PR TITLE
chore: dont expose error when not in test

### DIFF
--- a/lua/sf/test.lua
+++ b/lua/sf/test.lua
@@ -24,8 +24,15 @@ Test.open = function()
 end
 
 Test.run_current_test_with_coverage = function()
-  local test_class_name = H.validateInTestClass()
-  local test_name = H.validateInTestMethod()
+  local ok_class, test_class_name = pcall(H.validateInTestClass)
+  if not ok_class then
+    return
+  end
+
+  local ok_method, test_name = pcall(H.validateInTestMethod)
+  if not ok_method then
+    return
+  end
 
   local cmd = B:new():cmd('apex'):act('run test'):addParams({
     ['-t'] = test_class_name .. '.' .. test_name,
@@ -41,8 +48,15 @@ end
 ---@param cb function
 ---@return nil
 Test.run_current_test = function()
-  local test_class_name = H.validateInTestClass()
-  local test_name = H.validateInTestMethod()
+  local ok_class, test_class_name = pcall(H.validateInTestClass)
+  if not ok_class then
+    return
+  end
+
+  local ok_method, test_name = pcall(H.validateInTestMethod)
+  if not ok_method then
+    return
+  end
 
   -- local cmd = string.format("sf apex run test --tests %s.%s -r human -w 5 %s-o %s", test_class_name, test_name, extraParams, U.get())
   local cmd = B:new():cmd('apex'):act('run test'):addParams({
@@ -56,7 +70,10 @@ Test.run_current_test = function()
 end
 
 Test.run_all_tests_in_this_file_with_coverage = function()
-  local test_class_name = H.validateInTestClass()
+  local ok_class, test_class_name = pcall(H.validateInTestClass)
+  if not ok_class then
+    return
+  end
 
   local cmd = B:new():cmd('apex'):act('run test'):addParams({
     ['-n'] = test_class_name,
@@ -72,7 +89,10 @@ end
 ---@param cb function
 ---@return nil
 Test.run_all_tests_in_this_file = function(cb)
-  local test_class_name = H.validateInTestClass()
+  local ok_class, test_class_name = pcall(H.validateInTestClass)
+  if not ok_class then
+    return
+  end
 
   -- local cmd = string.format("sf apex run test --class-names %s -r human -w 5 %s-o %s", test_class_name, extraParams, U.get())
   local cmd = B:new():cmd('apex'):act('run test'):addParams({


### PR DESCRIPTION
This PR makes it so that when a user attempts to run a test file/method and not inside a test class/method, the warning shown is enough and the error message and stack trace are not surfaced to the end-user.

For most users, the warning message telling them they're not in the correct place to run those methods should be enough. Exposing the entire stack trace and error message to the user might give them the wrong impression that the plugin is unexpectedly failing, when in reality it is a handled failure. It also exposes unnecessary plugin internals to the end-user.
