### PR TITLE
feat: apply stylua formatting

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,2 @@
+indent_width = 2
+indent_type = "Spaces"

--- a/lua/sf/config.lua
+++ b/lua/sf/config.lua
@@ -1,5 +1,5 @@
 local Cfg = {}
-local AutoCmd = require('sf.sub.config_auto_cmd')
+local AutoCmd = require("sf.sub.config_auto_cmd")
 
 local default_cfg = {
   -- Unless you want to customize, no need to copy-paste any of these
@@ -20,7 +20,11 @@ local default_cfg = {
   -- This list defines what metadata filetypes have the "other hotkeys" enabled.
   -- For example, if you want to push/retrieve css files, it needs to be added into this list.
   hotkeys_in_filetypes = {
-    "apex", "sosl", "soql", "javascript", "html"
+    "apex",
+    "sosl",
+    "soql",
+    "javascript",
+    "html",
   },
 
   -- Define what metadata to be listed in `list_md_to_retrieve()` (<leader>ml)
@@ -29,30 +33,30 @@ local default_cfg = {
     "ApexClass",
     "ApexTrigger",
     "StaticResource",
-    "LightningComponentBundle"
+    "LightningComponentBundle",
   },
 
   -- Configuration for the integrated terminal
   term_config = {
-    ft = 'SFTerm',  -- term filetype
-    blend = 10,     -- background transparency: 0 is fully opaque; 100 is fully transparent
+    ft = "SFTerm", -- term filetype
+    blend = 10, -- background transparency: 0 is fully opaque; 100 is fully transparent
     dimensions = {
       height = 0.4, -- proportional of the editor height. 0.4 means 40%.
-      width = 0.8,  -- proportional of the editor width. 0.8 means 80%.
-      x = 0.5,      -- starting position of width. Details in `get_dimension()` in raw_term.lua source code.
-      y = 0.9,      -- starting position of height. Details in `get_dimension()` in raw_term.lua source code.
+      width = 0.8, -- proportional of the editor width. 0.8 means 80%.
+      x = 0.5, -- starting position of width. Details in `get_dimension()` in raw_term.lua source code.
+      y = 0.9, -- starting position of height. Details in `get_dimension()` in raw_term.lua source code.
     },
     -- `:h jobstart-options` for below options
-    border = 'single',
-    hl = 'Normal',
+    border = "single",
+    hl = "Normal",
     clear_env = false,
   },
 
   -- the sf project metadata folder, update this in case you diverged from the default sf folder structure
-  default_dir = '/force-app/main/default/',
+  default_dir = "/force-app/main/default/",
 
   -- the folder this plugin uses to store intermediate data. It's under the sf project root directory.
-  plugin_folder_name = '/sf_cache/',
+  plugin_folder_name = "/sf_cache/",
 
   -- after the test running with code coverage completes, display uncovered line sign automatically.
   -- you can set it to `false`, then manually run toggle_sign command.
@@ -60,13 +64,13 @@ local default_cfg = {
 
   -- code coverage sign icon colors
   code_sign_highlight = {
-    covered = { fg = "#b7f071" },   -- set `fg = ""` to disable this sign icon
+    covered = { fg = "#b7f071" }, -- set `fg = ""` to disable this sign icon
     uncovered = { fg = "#f07178" }, -- set `fg = ""` to disable this sign icon
   },
 }
 
 local apply_config = function(opt)
-  vim.g.sf = vim.tbl_deep_extend('force', default_cfg, opt)
+  vim.g.sf = vim.tbl_deep_extend("force", default_cfg, opt)
 end
 
 local init = function()
@@ -74,27 +78,27 @@ local init = function()
   vim.filetype = on
   vim.filetype.add({
     extension = {
-      cls = 'apex',
-      apex = 'apex',
-      trigger = 'apex',
-      soql = 'soql',
-      sosl = 'sosl',
-      page = 'html',
-      log = 'sflog',
-    }
+      cls = "apex",
+      apex = "apex",
+      trigger = "apex",
+      soql = "soql",
+      sosl = "sosl",
+      page = "html",
+      log = "sflog",
+    },
   })
 
   AutoCmd.set_auto_cmd_and_try_set_default_keys()
 
   -- Initiate the raw term
-  require('sf.term').setup(vim.g.sf.term_config)
+  require("sf.term").setup(vim.g.sf.term_config)
 
-  require('sf.test').setup_sign()
+  require("sf.test").setup_sign()
 end
 
 Cfg.setup = function(opt)
   opt = opt or {}
-  vim.validate({ config = { opt, 'table', true } })
+  vim.validate({ config = { opt, "table", true } })
   apply_config(opt)
 
   init()

--- a/lua/sf/ctags.lua
+++ b/lua/sf/ctags.lua
@@ -1,17 +1,18 @@
-local U = require('sf.util')
+local U = require("sf.util")
 local M = {}
 
 M.create = function()
-  U.is_ctags_installed();
-  local cmd = string.format('ctags --extras=+q --langmap=java:.cls.trigger -f ./tags -R **%sclasses/**', vim.g.sf.default_dir)
+  U.is_ctags_installed()
+  local cmd =
+    string.format("ctags --extras=+q --langmap=java:.cls.trigger -f ./tags -R **%sclasses/**", vim.g.sf.default_dir)
   U.silent_job_call(cmd, "Tags updated successfully.", "Error updating tags.")
 end
 
 M.create_and_list = function()
-  if not U.is_installed('fzf-lua') then
-    return U.show_err('fzf-lua is not installed. Need it to show the list.')
+  if not U.is_installed("fzf-lua") then
+    return U.show_err("fzf-lua is not installed. Need it to show the list.")
   end
   M.create()
-  require('fzf-lua').tags()
+  require("fzf-lua").tags()
 end
 return M

--- a/lua/sf/health.lua
+++ b/lua/sf/health.lua
@@ -12,7 +12,7 @@ end
 -- helper;
 
 H.check_sf_cli = function()
-  if vim.fn.executable('sf') ~= 1 then
+  if vim.fn.executable("sf") ~= 1 then
     return vim.health.error("sf cli not found!")
   end
 
@@ -20,22 +20,22 @@ H.check_sf_cli = function()
 end
 
 H.check_tree_sitter = function()
-  if not pcall(require, 'nvim-treesitter') then
+  if not pcall(require, "nvim-treesitter") then
     return vim.health.error("nvim-treesitter plugin not found!")
   end
   vim.health.ok("nvim-treesitter plugin found.")
 
-  local parsers = require('nvim-treesitter.parsers').get_parser_configs()
-  if parsers['apex'] == nil then
+  local parsers = require("nvim-treesitter.parsers").get_parser_configs()
+  if parsers["apex"] == nil then
     return vim.health.error("apex parser not installed in nvim-treesitter!")
   end
-  if parsers['soql'] == nil then
+  if parsers["soql"] == nil then
     return vim.health.error("soql parser not installed in nvim-treesitter!")
   end
-  if parsers['sosl'] == nil then
+  if parsers["sosl"] == nil then
     return vim.health.error("sosl parser not installed in nvim-treesitter!")
   end
-  if parsers['sflog'] == nil then
+  if parsers["sflog"] == nil then
     return vim.health.error("sflog parser not installed in nvim-treesitter!")
   end
   vim.health.ok("All Salesforce relevant parsers are installed in nvim-treesitter.")
@@ -46,22 +46,26 @@ H.check_nvim_version = function()
   local v_in_str = string.format("v%s.%s", v.major, v.minor)
 
   if v.major == 0 and v.minor < 10 then
-    return vim.health.error("installed Nvim version: " .. v_in_str .. ', plugin demands 0.10 or higher!')
+    return vim.health.error("installed Nvim version: " .. v_in_str .. ", plugin demands 0.10 or higher!")
   else
     vim.health.ok("nvim version ok: " .. v_in_str)
   end
 end
 
 H.check_fzf_lua = function()
-  if not pcall(require, 'fzf-lua') then
-    return vim.health.warn("Optional: fzf-lua not found. Some features for listing items won't work. You could install `ibhagwan/fzf-lua`.")
+  if not pcall(require, "fzf-lua") then
+    return vim.health.warn(
+      "Optional: fzf-lua not found. Some features for listing items won't work. You could install `ibhagwan/fzf-lua`."
+    )
   end
   vim.health.ok("fzf-lua plugin found.")
 end
 
 H.check_ctag = function()
-  if vim.fn.executable('ctags') ~= 1 then
-    return vim.health.warn("Optional: ctags command not found in the path. Enhanced apex jump-to-definition won't work. You could install `universal ctags`.")
+  if vim.fn.executable("ctags") ~= 1 then
+    return vim.health.warn(
+      "Optional: ctags command not found in the path. Enhanced apex jump-to-definition won't work. You could install `universal ctags`."
+    )
   end
 
   vim.health.ok("ctags command found.")

--- a/lua/sf/init.lua
+++ b/lua/sf/init.lua
@@ -4,20 +4,19 @@
 --- MIT License Copyright (c) 2024 Xi Xiao
 ---
 
-local Util = require('sf.util')
-local Term = require('sf.term')
-local Org = require('sf.org')
-local Metadata = require('sf.md')
-local Test = require('sf.test')
-local Ctags = require('sf.ctags')
+local Util = require("sf.util")
+local Term = require("sf.term")
+local Org = require("sf.org")
+local Metadata = require("sf.md")
+local Test = require("sf.test")
+local Ctags = require("sf.ctags")
 local Sf = {}
 
 --- Before using this plugin, it's mandatory to invoke this function by "require'sf'.setup()".
 ---@param opt table|nil Optional config table to overwrite default settings.
 Sf.setup = function(opt)
-  require('sf.config').setup(opt)
+  require("sf.config").setup(opt)
 end
-
 
 --- get the value of the plugin internal variable "target_org".
 --- "target_org" is automatically set by |Sf.fetch_org_list| when Nvim is intitiated
@@ -178,6 +177,5 @@ Sf.create_ctags = Ctags.create
 --- Create tags file in the root path and list them by fzf plugin.
 --- When fzf is not found, the command exists with an error msg.
 Sf.create_and_list_ctags = Ctags.create_and_list
-
 
 return Sf

--- a/lua/sf/md.lua
+++ b/lua/sf/md.lua
@@ -1,6 +1,6 @@
-local T = require('sf.term')
-local U = require('sf.util')
-local B = require('sf.sub.cmd_builder')
+local T = require("sf.term")
+local U = require("sf.util")
+local B = require("sf.sub.cmd_builder")
 local H = {}
 
 local Md = {}
@@ -41,12 +41,14 @@ end
 
 ---@param name string
 H.open_apex = function(name)
-  U.try_open_file(U.get_apex_folder_path() .. name .. '.cls')
+  U.try_open_file(U.get_apex_folder_path() .. name .. ".cls")
 end
 
 H.retrieve_apex_under_cursor = function()
-  local current_word = vim.fn.expand('<cword>')
-  H.retrieve_md('ApexClass', current_word, function() H.open_apex(current_word) end)
+  local current_word = vim.fn.expand("<cword>")
+  H.retrieve_md("ApexClass", current_word, function()
+    H.open_apex(current_word)
+  end)
 end
 
 ---@param type string
@@ -55,22 +57,22 @@ end
 ---@return nil
 H.retrieve_md = function(type, name, cb)
   if U.is_empty_str(U.target_org) then
-    return U.show_err('Target_org empty!')
+    return U.show_err("Target_org empty!")
   end
   U.get_sf_root()
 
-  local type_name = string.format('%s:%s', type, name)
-  local cmd = B:new():cmd('project'):act('retrieve start'):addParams('-m', type_name):build()
+  local type_name = string.format("%s:%s", type, name)
+  local cmd = B:new():cmd("project"):act("retrieve start"):addParams("-m", type_name):build()
   T.run(cmd, cb)
 end
 
 H.list_md_to_retrieve = function()
   if U.is_empty_str(U.target_org) then
-    return U.show_err('Target_org empty!')
+    return U.show_err("Target_org empty!")
   end
 
-  if not U.is_installed('fzf-lua') then
-    return U.show_err('fzf-lua is not installed. Need it to show the list.')
+  if not U.is_installed("fzf-lua") then
+    return U.show_err("fzf-lua is not installed. Need it to show the list.")
   end
 
   local md_types = vim.g.sf.types_to_retrieve
@@ -78,41 +80,43 @@ H.list_md_to_retrieve = function()
   local md_names = {}
 
   for _, type in pairs(md_types) do
-    local file = string.format('%s_%s.json', type, U.target_org)
+    local file = string.format("%s_%s.json", type, U.target_org)
     local md_tbl = U.read_file_json_to_tbl(file, U.get_plugin_folder_path())
 
     if md_tbl ~= nil then
-    for _, v in ipairs(md_tbl) do
-      if v["manageableState"] == 'unmanaged' then
-        md[v["fullName"]] = v
-        table.insert(md_names, v["fullName"])
+      for _, v in ipairs(md_tbl) do
+        if v["manageableState"] == "unmanaged" then
+          md[v["fullName"]] = v
+          table.insert(md_names, v["fullName"])
+        end
       end
     end
   end
-end
 
   require("fzf-lua").fzf_exec(md_names, {
     actions = {
-      ['default'] = function(selected)
-        H.retrieve_md(md[selected[1]]["type"], selected[1], function() H.open_apex(selected[1]) end)
-      end
+      ["default"] = function(selected)
+        H.retrieve_md(md[selected[1]]["type"], selected[1], function()
+          H.open_apex(selected[1])
+        end)
+      end,
     },
     fzf_opts = {
-      ['--preview-window'] = 'nohidden,down,50%',
-      ['--preview'] = function(items)
+      ["--preview-window"] = "nohidden,down,50%",
+      ["--preview"] = function(items)
         local contents = {}
         vim.tbl_map(function(x)
           table.insert(contents, "\n" .. U.table_to_string_lines(md[x]))
         end, items)
         return contents
-      end
+      end,
     },
   })
 end
 
 H.pull_md_json = function()
   if U.is_empty_str(U.target_org) then
-    return U.show_err('Target_org empty!')
+    return U.show_err("Target_org empty!")
   end
   local md_types = vim.g.sf.types_to_retrieve
   for _, type in pairs(md_types) do
@@ -124,44 +128,44 @@ end
 ---@return nil
 H.pull_metadata = function(type)
   if U.is_empty_str(U.target_org) then
-    return U.show_err('Target_org empty!')
+    return U.show_err("Target_org empty!")
   end
 
   U.create_plugin_folder_if_not_exist()
 
-  local md_file = string.format('%s%s_%s.json', U.get_plugin_folder_path(), type, U.target_org)
+  local md_file = string.format("%s%s_%s.json", U.get_plugin_folder_path(), type, U.target_org)
 
   -- local cmd = string.format('sf org list metadata -m %s -o %s -f %s', type, U.target_org, md_file)
-  local cmd = B:new():cmd('org'):act('list metadata'):addParams({ ["-m"] = type, ["-f"] = md_file }):build()
-  local msg = string.format('%s retrieved', type)
-  local err_msg = string.format('%s retrieve failed: %s', type, md_file)
+  local cmd = B:new():cmd("org"):act("list metadata"):addParams({ ["-m"] = type, ["-f"] = md_file }):build()
+  local msg = string.format("%s retrieved", type)
+  local err_msg = string.format("%s retrieve failed: %s", type, md_file)
 
-  U.silent_job_call(cmd, msg, err_msg);
+  U.silent_job_call(cmd, msg, err_msg)
 end
 
 H.pull_md_type_json = function()
   if U.is_empty_str(U.target_org) then
-    return U.show_err('Target_org empty!')
+    return U.show_err("Target_org empty!")
   end
 
   U.create_plugin_folder_if_not_exist()
 
-  local metadata_types_file = string.format('%s%s.json', U.get_plugin_folder_path(), 'metadata-types')
+  local metadata_types_file = string.format("%s%s.json", U.get_plugin_folder_path(), "metadata-types")
   -- local cmd = string.format('sf org list metadata-types -o %s -f %s', U.target_org, metadata_types_file)
-  local cmd = B:new():cmd('org'):act('list metadata-types'):addParams('-f', metadata_types_file):build()
-  local msg = 'Metadata-type file retrieved'
-  local err_msg = string.format('Metadata-type retrieve failed: %s', metadata_types_file)
+  local cmd = B:new():cmd("org"):act("list metadata-types"):addParams("-f", metadata_types_file):build()
+  local msg = "Metadata-type file retrieved"
+  local err_msg = string.format("Metadata-type retrieve failed: %s", metadata_types_file)
 
-  U.silent_job_call(cmd, msg, err_msg);
+  U.silent_job_call(cmd, msg, err_msg)
 end
 
 H.list_md_type_to_retrieve = function()
   if U.is_empty_str(U.target_org) then
-    return U.show_err('Target_org empty!')
+    return U.show_err("Target_org empty!")
   end
 
-  if not U.is_installed('fzf-lua') then
-    return U.show_err('fzf-lua is not installed. Need it to show the list.')
+  if not U.is_installed("fzf-lua") then
+    return U.show_err("fzf-lua is not installed. Need it to show the list.")
   end
 
   local tbl = U.read_file_json_to_tbl("metadata-types.json", U.get_plugin_folder_path())
@@ -173,10 +177,10 @@ H.list_md_type_to_retrieve = function()
 
   require("fzf-lua").fzf_exec(md_types, {
     actions = {
-      ['default'] = function(selected)
+      ["default"] = function(selected)
         H.retrieve_md_type(selected[1])
-      end
-    }
+      end,
+    },
   })
 end
 
@@ -184,13 +188,13 @@ end
 ---@return nil
 H.retrieve_md_type = function(type)
   if U.is_empty_str(U.target_org) then
-    return U.show_err('Target_org empty!')
+    return U.show_err("Target_org empty!")
   end
 
   U.get_sf_root()
 
   -- local cmd = string.format('sf project retrieve start -m \'%s:*\' -o %s', type, U.target_org)
-  local cmd = B:new():cmd('project'):act('retrieve start'):addParams('-m', type):build()
+  local cmd = B:new():cmd("project"):act("retrieve start"):addParams("-m", type):build()
   T.run(cmd)
 end
 
@@ -198,17 +202,12 @@ end
 H.generate_class = function(name)
   local path = U.get_apex_folder_path()
   -- local cmd = string.format("sf apex generate class --output-dir %s --name %s", path, name)
-  local cmd = B:new():cmd('apex'):act('generate class'):addParams({ ["-d"] = path, ["-n"] = name }):localOnly():build()
+  local cmd = B:new():cmd("apex"):act("generate class"):addParams({ ["-d"] = path, ["-n"] = name }):localOnly():build()
 
-  U.job_call(
-    cmd,
-    nil,
-    "Something went wrong creating the class",
-    function()
-      local absolute_path = path .. name .. '.cls'
-      U.try_open_file(absolute_path)
-    end
-  )
+  U.job_call(cmd, nil, "Something went wrong creating the class", function()
+    local absolute_path = path .. name .. ".cls"
+    U.try_open_file(absolute_path)
+  end)
 end
 
 ---@param name string
@@ -219,15 +218,15 @@ end
 ---@param name string
 H.generate_aura = function(name)
   -- local cmd = string.format("sf lightning generate component --output-dir %s --name %s --type aura", U.get_default_dir_path() .. "/aura", name)
-  local cmd = B:new():cmd('lightning'):act('generate component'):addParams({ ["-d"] = U.get_default_dir_path() .. 'aura', ['-n'] = name, ['--type'] = 'aura' }):localOnly():build()
-  U.silent_job_call(
-    cmd,
-    nil,
-    "Something went wrong creating the Aura bundle",
-    function()
-      U.try_open_file(U.get_default_dir_path() .. 'aura/' .. name .. '/' .. name .. '.cmp')
-    end
-  )
+  local cmd = B:new()
+    :cmd("lightning")
+    :act("generate component")
+    :addParams({ ["-d"] = U.get_default_dir_path() .. "aura", ["-n"] = name, ["--type"] = "aura" })
+    :localOnly()
+    :build()
+  U.silent_job_call(cmd, nil, "Something went wrong creating the Aura bundle", function()
+    U.try_open_file(U.get_default_dir_path() .. "aura/" .. name .. "/" .. name .. ".cmp")
+  end)
 end
 
 ---@param name string
@@ -238,15 +237,15 @@ end
 ---@param name string
 H.generate_lwc = function(name)
   -- local cmd = string.format("sf lightning generate component --output-dir %s --name %s --type lwc", U.get_sf_root() .. vim.g.sf.default_dir .. "/lwc", name)
-  local cmd = B:new():cmd('lightning'):act('generate component'):addParams({ ["-d"] = U.get_default_dir_path() .. 'lwc', ['-n'] = name, ['--type'] = 'lwc' }):localOnly():build()
-  U.silent_job_call(
-    cmd,
-    nil,
-    "Something went wrong creating the LWC bundle",
-    function()
-      U.try_open_file(U.get_default_dir_path() .. 'lwc/' .. name .. '/' .. name .. '.js')
-    end
-  )
+  local cmd = B:new()
+    :cmd("lightning")
+    :act("generate component")
+    :addParams({ ["-d"] = U.get_default_dir_path() .. "lwc", ["-n"] = name, ["--type"] = "lwc" })
+    :localOnly()
+    :build()
+  U.silent_job_call(cmd, nil, "Something went wrong creating the LWC bundle", function()
+    U.try_open_file(U.get_default_dir_path() .. "lwc/" .. name .. "/" .. name .. ".js")
+  end)
 end
 
 ---@param name string

--- a/lua/sf/org.lua
+++ b/lua/sf/org.lua
@@ -1,5 +1,5 @@
-local U = require('sf.util')
-local B = require('sf.sub.cmd_builder')
+local U = require("sf.util")
+local B = require("sf.sub.cmd_builder")
 
 local H = {}
 local Org = {}
@@ -26,15 +26,15 @@ end
 
 function Org.open()
   -- local cmd = 'sf org open -o ' .. U.get()
-  local cmd = B:new():cmd('org'):act('open'):build()
-  local err_msg = 'Command failed: ' .. cmd
+  local cmd = B:new():cmd("org"):act("open"):build()
+  local err_msg = "Command failed: " .. cmd
   U.job_call(cmd, nil, err_msg)
 end
 
 function Org.open_current_file()
   -- local cmd = vim.fn.expandcmd('sf org open --source-file "%:p" -o ') .. U.get()
-  local cmd = B:new():cmd('org'):act('open'):addParams('-f', '%:p'):build()
-  local err_msg = 'Command failed: ' .. cmd
+  local cmd = B:new():cmd("org"):act("open"):addParams("-f", "%:p"):build()
+  local err_msg = "Command failed: " .. cmd
   U.job_call(cmd, nil, err_msg)
 end
 
@@ -49,12 +49,12 @@ end
 H.set_target_org = function()
   U.is_table_empty(H.orgs)
   vim.ui.select(H.orgs, {
-    prompt = 'Local target_org:'
+    prompt = "Local target_org:",
   }, function(choice)
     if choice ~= nil then
-      local org = string.gsub(choice, '%[S%] ', '')
-      local cmd = 'sf config set target-org ' .. org
-      local err_msg = org .. ' - set target_org failed! Not in a sfdx project folder?'
+      local org = string.gsub(choice, "%[S%] ", "")
+      local cmd = "sf config set target-org " .. org
+      local err_msg = org .. " - set target_org failed! Not in a sfdx project folder?"
       local cb = function()
         U.target_org = org
       end
@@ -66,17 +66,17 @@ end
 
 H.set_global_target_org = function()
   if U.is_empty_str(H.orgs) then
-    U.notify_then_error('Empty value')
+    U.notify_then_error("Empty value")
   end
 
   vim.ui.select(H.orgs, {
-    prompt = 'Global target_org:'
+    prompt = "Global target_org:",
   }, function(choice)
     if choice ~= nil then
-      local org = string.gsub(choice, '%[S%] ', '')
-      local cmd = 'sf config set target-org --global ' .. org
-      local msg = 'Global target_org set: ' .. org
-      local err_msg = string.format('Global set target_org [%s] failed!', org)
+      local org = string.gsub(choice, "%[S%] ", "")
+      local cmd = "sf config set target-org --global " .. org
+      local msg = "Global target_org set: " .. org
+      local err_msg = string.format("Global set target_org [%s] failed!", org)
       local cb = function()
         U.target_org = org
       end
@@ -89,7 +89,7 @@ end
 H.store_orgs = function(data)
   local s = ""
   for _, v in ipairs(data) do
-    s = s .. v;
+    s = s .. v
   end
 
   local org_data = vim.json.decode(s, {}).result.nonScratchOrgs
@@ -105,7 +105,7 @@ H.store_orgs = function(data)
       U.target_org = alias
     end
 
-    local org_entry = v.isScratch and '[S] ' .. alias or alias
+    local org_entry = v.isScratch and "[S] " .. alias or alias
     table.insert(H.orgs, org_entry)
   end
 
@@ -113,12 +113,11 @@ H.store_orgs = function(data)
 end
 
 H.fetch_and_store_orgs = function()
-  vim.fn.jobstart('sf org list --json', {
+  vim.fn.jobstart("sf org list --json", {
     stdout_buffered = true,
-    on_stdout =
-        function(_, data)
-          H.store_orgs(data)
-        end
+    on_stdout = function(_, data)
+      H.store_orgs(data)
+    end,
   })
 end
 
@@ -131,7 +130,7 @@ end
 
 H.diff_in_target_org = function()
   if U.is_empty_str(U.target_org) then
-    return U.show_err('Target_org empty!')
+    return U.show_err("Target_org empty!")
   end
 
   H.diff_in(U.target_org)
@@ -141,7 +140,7 @@ H.diff_in_org = function()
   U.is_table_empty(H.orgs)
 
   vim.ui.select(H.orgs, {
-    prompt = 'Select org to diff in:'
+    prompt = "Select org to diff in:",
   }, function(choice)
     if choice ~= nil then
       H.diff_in(choice)
@@ -163,14 +162,19 @@ H.diff_in = function(org)
   --   temp_path,
   --   org
   -- )
-  local cmd = B:new():cmd('project'):act('retrieve start'):addParams({
-    ['-m'] = metadataType .. ':' .. file_name_no_ext,
-    ['-r'] = temp_path,
-    ['--json'] = '',
-  }):set_org(org):build()
+  local cmd = B:new()
+    :cmd("project")
+    :act("retrieve start")
+    :addParams({
+      ["-m"] = metadataType .. ":" .. file_name_no_ext,
+      ["-r"] = temp_path,
+      ["--json"] = "",
+    })
+    :set_org(org)
+    :build()
 
-  local msg = 'Retrive success: ' .. org
-  local err_msg = 'Retrive failed: ' .. org
+  local msg = "Retrive success: " .. org
+  local err_msg = "Retrive failed: " .. org
   local cb = function()
     local temp_file = H.find_file(temp_path, file_name)
     vim.cmd("vert diffsplit " .. temp_file)
@@ -228,7 +232,7 @@ H.find_file = function(path, target)
   -- if scanner is nil, then path is not a valid dir
   if scanner then
     local file, type = vim.loop.fs_scandir_next(scanner)
-    if (path:sub(-1) ~= "/") then
+    if path:sub(-1) ~= "/" then
       path = path .. "/"
     end
     while file do

--- a/lua/sf/sub/cmd_builder.lua
+++ b/lua/sf/sub/cmd_builder.lua
@@ -1,4 +1,4 @@
-local U = require('sf.util')
+local U = require("sf.util")
 
 ---@class CommandBuilder
 ---@field base_cmd string
@@ -14,151 +14,154 @@ CommandBuilder.__index = CommandBuilder
 ---@param base_command string|nil
 ---@return CommandBuilder
 function CommandBuilder:new(base_command)
-    local obj = setmetatable({
-        base_cmd = base_command or "sf",
-        command = "",
-        action = "",
-        params = {},
-        param_str = "",
-        org = U.target_org or nil,
-        require_org = true,
-    }, CommandBuilder)
-    return obj
+  local obj = setmetatable({
+    base_cmd = base_command or "sf",
+    command = "",
+    action = "",
+    params = {},
+    param_str = "",
+    org = U.target_org or nil,
+    require_org = true,
+  }, CommandBuilder)
+  return obj
 end
 
 ---Set the command
 ---@param cmd string
 ---@return CommandBuilder
 function CommandBuilder:cmd(cmd)
-    self.command = cmd
-    return self
+  self.command = cmd
+  return self
 end
 
 ---Set the action
 ---@param action string
 ---@return CommandBuilder
 function CommandBuilder:act(action)
-    self.action = action
-    return self
+  self.action = action
+  return self
 end
 
 ---Make the command local only
 ---@return CommandBuilder
 function CommandBuilder:localOnly()
-    self.require_org = false
-    return self
+  self.require_org = false
+  return self
 end
 
 ---Add one or more parameters
 ---@param ... string|table Either a flag and value as separate arguments, or a table of flag-value pairs
 ---@return CommandBuilder
 function CommandBuilder:addParams(...)
-    local args = { ... }
-    if type(args[1]) == "table" then
-        -- If a table is passed, assume it's a list of flag-value pairs
-        for flag, value in pairs(args[1]) do
-            self.params[flag] = value
-        end
-    else
-        -- If individual arguments are passed, assume it's a single flag-value pair
-        local flag, value = args[1], args[2] or ''
-        self.params[flag] = value
+  local args = { ... }
+  if type(args[1]) == "table" then
+    -- If a table is passed, assume it's a list of flag-value pairs
+    for flag, value in pairs(args[1]) do
+      self.params[flag] = value
     end
-    return self
+  else
+    -- If individual arguments are passed, assume it's a single flag-value pair
+    local flag, value = args[1], args[2] or ""
+    self.params[flag] = value
+  end
+  return self
 end
 
 ---Set the param str. When params are given as string or the flag is the same for multiple params
 ---@param param_str string
 ---@return CommandBuilder
 function CommandBuilder:addParamStr(param_str)
-    self.param_str = param_str
-    return self
+  self.param_str = param_str
+  return self
 end
 
 ---Set the org property
 ---@param org string
 ---@return CommandBuilder
 function CommandBuilder:set_org(org)
-    self.org = org
-    return self
+  self.org = org
+  return self
 end
 
 ---Validate the command
 function CommandBuilder:validate()
-    local required_fields = {
-        { field = "command", message = '"command" property not set' },
-        { field = "action",  message = '"action" property not set' },
-        { field = "org",     message = 'no given org value nor default target_org' }
-    }
+  local required_fields = {
+    { field = "command", message = '"command" property not set' },
+    { field = "action", message = '"action" property not set' },
+    { field = "org", message = "no given org value nor default target_org" },
+  }
 
-    for _, field in ipairs(required_fields) do
-        if U.is_empty_str(self[field.field]) then
-            U.notify_then_error('Invalid cmd building: ' .. field.message)
-        end
+  for _, field in ipairs(required_fields) do
+    if U.is_empty_str(self[field.field]) then
+      U.notify_then_error("Invalid cmd building: " .. field.message)
     end
+  end
 end
 
 ---Sort the params based on the specified rules
 ---@return table<integer, {flag: string, value: string}>
 function CommandBuilder:sortParams()
-    local paramsWithValue = {}
-    local paramsWithoutValue = {}
+  local paramsWithValue = {}
+  local paramsWithoutValue = {}
 
-    for flag, value in pairs(self.params) do
-        if value ~= "" then
-            table.insert(paramsWithValue, { flag = flag, value = value })
-        else
-            table.insert(paramsWithoutValue, { flag = flag, value = value })
-        end
+  for flag, value in pairs(self.params) do
+    if value ~= "" then
+      table.insert(paramsWithValue, { flag = flag, value = value })
+    else
+      table.insert(paramsWithoutValue, { flag = flag, value = value })
     end
+  end
 
-    table.sort(paramsWithValue, function(a, b) return a.flag < b.flag end)
-    table.sort(paramsWithoutValue, function(a, b) return a.flag < b.flag end)
+  table.sort(paramsWithValue, function(a, b)
+    return a.flag < b.flag
+  end)
+  table.sort(paramsWithoutValue, function(a, b)
+    return a.flag < b.flag
+  end)
 
-    for _, param in ipairs(paramsWithoutValue) do
-        table.insert(paramsWithValue, param)
-    end
+  for _, param in ipairs(paramsWithoutValue) do
+    table.insert(paramsWithValue, param)
+  end
 
-    return paramsWithValue
+  return paramsWithValue
 end
 
 ---Build the final command string
 ---@return string
 function CommandBuilder:build()
-    self:validate()
+  self:validate()
 
-    local cmd = string.format('%s %s %s',
-        self.base_cmd, self.command, self.action)
+  local cmd = string.format("%s %s %s", self.base_cmd, self.command, self.action)
 
-    local sortedParams = self:sortParams()
-    if #sortedParams > 0 then
-        local param_strings = {}
-        for _, param in ipairs(sortedParams) do
-            if param.value == "" then
-                table.insert(param_strings, param.flag)
-            else
-                local expanded_value = string.format('"%s"', vim.fn.expandcmd(param.value))
-                table.insert(param_strings, param.flag .. " " .. expanded_value)
-            end
-        end
-        cmd = cmd .. " " .. table.concat(param_strings, " ")
+  local sortedParams = self:sortParams()
+  if #sortedParams > 0 then
+    local param_strings = {}
+    for _, param in ipairs(sortedParams) do
+      if param.value == "" then
+        table.insert(param_strings, param.flag)
+      else
+        local expanded_value = string.format('"%s"', vim.fn.expandcmd(param.value))
+        table.insert(param_strings, param.flag .. " " .. expanded_value)
+      end
     end
+    cmd = cmd .. " " .. table.concat(param_strings, " ")
+  end
 
-    if not U.is_empty_str(self.param_str) then
-        cmd = cmd .. ' ' .. self.param_str
-    end
+  if not U.is_empty_str(self.param_str) then
+    cmd = cmd .. " " .. self.param_str
+  end
 
-    if self.require_org then
-      local org_param = string.format('-o "%s"', self.org)
-      cmd = cmd .. " " .. org_param
-    end
+  if self.require_org then
+    local org_param = string.format('-o "%s"', self.org)
+    cmd = cmd .. " " .. org_param
+  end
 
-    return cmd
+  return cmd
 end
 
 function CommandBuilder:t()
-    local t = "%:p"
-    return vim.fn.expandcmd(t)
+  local t = "%:p"
+  return vim.fn.expandcmd(t)
 end
 
 return CommandBuilder

--- a/lua/sf/sub/config_auto_cmd.lua
+++ b/lua/sf/sub/config_auto_cmd.lua
@@ -5,46 +5,46 @@ M.set_auto_cmd_and_try_set_default_keys = function()
 
   -- Disable "end of line" for relevant filetypes in sf project folder,
   -- Because metadata files retrieved from Salesforce don't have it
-  vim.api.nvim_create_autocmd({ 'FileType' }, {
+  vim.api.nvim_create_autocmd({ "FileType" }, {
     group = sf_group,
-    pattern = { 'javascript, apex, html' },
+    pattern = { "javascript, apex, html" },
     callback = function()
-      if pcall(require('sf.util').get_sf_root) then
+      if pcall(require("sf.util").get_sf_root) then
         vim.bo.fixendofline = false -- FIXME: it seems not set correctly. Check why.
       end
-    end
+    end,
   })
 
-  vim.api.nvim_create_autocmd({ 'FileType' }, {
+  vim.api.nvim_create_autocmd({ "FileType" }, {
     group = sf_group,
-    pattern = 'apex',
+    pattern = "apex",
     callback = function()
-      vim.bo.commentstring = '//%s'
+      vim.bo.commentstring = "//%s"
       vim.bo.fixendofline = false
 
       -- try refresh code coverage signs in the new opened Apex file
-      local t = require('sf.test')
+      local t = require("sf.test")
       if t.is_sign_enabled() then
         t.refresh_and_place_sign()
       end
-    end
+    end,
   })
 
   -- Set hotkeys for the integrated terminal
-  vim.api.nvim_create_autocmd({ 'FileType' }, {
+  vim.api.nvim_create_autocmd({ "FileType" }, {
     group = sf_group,
-    pattern = 'SFTerm',
+    pattern = "SFTerm",
     callback = function()
       local nmap = function(keys, func, desc)
         if desc then
-          desc = desc .. ' [Sf]'
+          desc = desc .. " [Sf]"
         end
-        vim.keymap.set('n', keys, func, { buffer = true, desc = desc })
+        vim.keymap.set("n", keys, func, { buffer = true, desc = desc })
       end
 
-      nmap('<leader><leader>', require('sf').toggle_term, 'terminal toggle')
-      nmap('<C-c>', require('sf').cancel, 'cancel running command')
-    end
+      nmap("<leader><leader>", require("sf").toggle_term, "terminal toggle")
+      nmap("<C-c>", require("sf").cancel, "cancel running command")
+    end,
   })
 
   -- Refresh test code coverage info for the current Apex file
@@ -52,44 +52,44 @@ M.set_auto_cmd_and_try_set_default_keys = function()
     group = sf_group,
     pattern = { "*.cls" },
     callback = function()
-      local ok, content = pcall(require('sf').refresh_current_file_covered_percent)
+      local ok, content = pcall(require("sf").refresh_current_file_covered_percent)
       if not ok then
         -- swallow error and be silent
       end
-    end
+    end,
   })
 
   -- Fetch org info in Vim start
   if vim.g.sf.fetch_org_list_at_nvim_start then
-    vim.api.nvim_create_autocmd({ 'VimEnter' }, {
+    vim.api.nvim_create_autocmd({ "VimEnter" }, {
       group = sf_group,
-      desc = 'Run sf org cmd and store org info in the plugin',
+      desc = "Run sf org cmd and store org info in the plugin",
       callback = function()
-        if vim.fn.executable('sf') == 1 then
-          require('sf').fetch_org_list()
+        if vim.fn.executable("sf") == 1 then
+          require("sf").fetch_org_list()
         end
       end,
     })
   end
 
   local function try_set_keys_and_user_commands()
-    if not pcall(require('sf.util').get_sf_root) then
+    if not pcall(require("sf.util").get_sf_root) then
       return
     end
 
-    require('sf.sub.config_user_command').create_user_commands()
+    require("sf.sub.config_user_command").create_user_commands()
 
     if not vim.g.sf.enable_hotkeys then
       return
     end
 
-    require('sf.sub.config_user_key').set_default_hotkeys()
+    require("sf.sub.config_user_key").set_default_hotkeys()
   end
 
   -- Set hotkeys and user commands
-  vim.api.nvim_create_autocmd({ 'BufWinEnter', 'FileType', 'DirChanged' }, {
+  vim.api.nvim_create_autocmd({ "BufWinEnter", "FileType", "DirChanged" }, {
     group = sf_group,
-    callback = try_set_keys_and_user_commands
+    callback = try_set_keys_and_user_commands,
   })
 end
 

--- a/lua/sf/sub/config_user_command.lua
+++ b/lua/sf/sub/config_user_command.lua
@@ -1,10 +1,10 @@
 local M = {}
-local Sf = require('sf')
-local U = require('sf.util')
+local Sf = require("sf")
+local U = require("sf.util")
 
 local complete = function(supported_args, subcmd_arg_lead)
   local filtered_args = vim.tbl_filter(function(arg)
-    return arg:find('^' .. vim.pesc(subcmd_arg_lead)) ~= nil
+    return arg:find("^" .. vim.pesc(subcmd_arg_lead)) ~= nil
   end, supported_args)
 
   table.sort(filtered_args)
@@ -16,13 +16,12 @@ local common_complete = function(sub_cmd, subcmd_arg_lead)
 end
 
 local common_impl = function(sub_cmd, arg)
-  local func = vim.tbl_get(M.sub_cmd_tbl, sub_cmd, 'funcs', arg)
+  local func = vim.tbl_get(M.sub_cmd_tbl, sub_cmd, "funcs", arg)
   if not func then
     return U.show_err(string.format("'%s %s' is not a valid command", sub_cmd, arg))
   end
   func()
 end
-
 
 ---@type table<string, {impl: fun(sub_cmd: string, arg: string): any, complete: fun(subcmd_arg_lead: string): string[], funcs: table<string, fun(...): any>}>
 M.sub_cmd_tbl = {
@@ -32,31 +31,31 @@ M.sub_cmd_tbl = {
       retrieve = Sf.retrieve,
       diff = Sf.diff_in_target_org,
       diffIn = Sf.diff_in_org,
-      RunAsAnonymous = Sf.run_anonymous
+      RunAsAnonymous = Sf.run_anonymous,
     },
     impl = common_impl,
     complete = function(subcmd_arg_lead)
-      return common_complete('currentFile', subcmd_arg_lead)
+      return common_complete("currentFile", subcmd_arg_lead)
     end,
   },
   md = {
     funcs = {
       pull = Sf.pull_md_json,
-      list = Sf.list_md_to_retrieve
+      list = Sf.list_md_to_retrieve,
     },
     impl = common_impl,
     complete = function(subcmd_arg_lead)
-      return common_complete('md', subcmd_arg_lead)
+      return common_complete("md", subcmd_arg_lead)
     end,
   },
   mdtype = {
     funcs = {
       pull = Sf.pull_md_type_json,
-      list = Sf.list_md_type_to_retrieve
+      list = Sf.list_md_type_to_retrieve,
     },
     impl = common_impl,
     complete = function(subcmd_arg_lead)
-      return common_complete('mdtype', subcmd_arg_lead)
+      return common_complete("mdtype", subcmd_arg_lead)
     end,
   },
   org = {
@@ -65,11 +64,11 @@ M.sub_cmd_tbl = {
       setGlobalTarget = Sf.set_global_target_org,
       fetchList = Sf.fetch_org_list,
       open = Sf.org_open,
-      openCurrentFile = Sf.org_open_current_file
+      openCurrentFile = Sf.org_open_current_file,
     },
     impl = common_impl,
     complete = function(subcmd_arg_lead)
-      return common_complete('org', subcmd_arg_lead)
+      return common_complete("org", subcmd_arg_lead)
     end,
   },
   term = {
@@ -79,7 +78,7 @@ M.sub_cmd_tbl = {
     },
     impl = common_impl,
     complete = function(subcmd_arg_lead)
-      return common_complete('term', subcmd_arg_lead)
+      return common_complete("term", subcmd_arg_lead)
     end,
   },
   test = {
@@ -87,11 +86,11 @@ M.sub_cmd_tbl = {
       currentTest = Sf.run_current_test,
       allTestsInThisFile = Sf.run_all_tests_in_this_file,
       select = Sf.open_test_select,
-      allTestsInOrg = Sf.run_local_tests
+      allTestsInOrg = Sf.run_local_tests,
     },
     impl = common_impl,
     complete = function(subcmd_arg_lead)
-      return common_complete('test', subcmd_arg_lead)
+      return common_complete("test", subcmd_arg_lead)
     end,
   },
   create = {
@@ -104,7 +103,7 @@ M.sub_cmd_tbl = {
     },
     impl = common_impl,
     complete = function(subcmd_arg_lead)
-      return common_complete('create', subcmd_arg_lead)
+      return common_complete("create", subcmd_arg_lead)
     end,
   },
 }
@@ -133,22 +132,19 @@ M.create_user_commands = function()
     complete = function(arg_lead, cmdline, _)
       -- sub_cmd complete
       local subcmd, subcmd_arg_lead = cmdline:match("^['<,'>]*SF[!]*%s(%S+)%s(.*)$")
-      if subcmd
-          and subcmd_arg_lead
-          and M.sub_cmd_tbl[subcmd]
-          and M.sub_cmd_tbl[subcmd].complete
-      then
+      if subcmd and subcmd_arg_lead and M.sub_cmd_tbl[subcmd] and M.sub_cmd_tbl[subcmd].complete then
         return M.sub_cmd_tbl[subcmd].complete(subcmd_arg_lead)
       end
 
       -- sub_cmd with args complete
       if cmdline:match("^['<,'>]*SF[!]*%s+%w*$") then
         local sub_cmd_keys = vim.tbl_keys(M.sub_cmd_tbl)
-        return vim.iter(sub_cmd_keys)
-            :filter(function(key)
-              return key:find(arg_lead) ~= nil
-            end)
-            :totable()
+        return vim
+          .iter(sub_cmd_keys)
+          :filter(function(key)
+            return key:find(arg_lead) ~= nil
+          end)
+          :totable()
       end
     end,
   })

--- a/lua/sf/sub/config_user_key.lua
+++ b/lua/sf/sub/config_user_key.lua
@@ -3,48 +3,48 @@ local M = {}
 M.set_default_hotkeys = function()
   local nmap = function(keys, func, desc)
     if desc then
-      desc = desc .. ' [Sf]'
+      desc = desc .. " [Sf]"
     end
-    vim.keymap.set('n', keys, func, { buffer = true, desc = desc })
+    vim.keymap.set("n", keys, func, { buffer = true, desc = desc })
   end
 
-  local Sf = require('sf')
+  local Sf = require("sf")
 
   -- Common hotkeys for all files;
-  nmap('<leader>ss', Sf.set_target_org, "set target_org current workspace")
-  nmap('<leader>sS', Sf.set_global_target_org, "set global target_org")
-  nmap('<leader>sf', Sf.fetch_org_list, "fetch orgs info")
-  nmap('<leader>ml', Sf.list_md_to_retrieve, "metadata listing")
-  nmap('<leader>mtl', Sf.list_md_type_to_retrieve, "metadata-type listing")
-  nmap('<leader><leader>', Sf.toggle_term, "terminal toggle")
-  nmap('<C-c>', Sf.cancel, "cancel running command")
-  nmap('<leader>s-', Sf.go_to_sf_root, "cd into root")
-  nmap('<leader>ct', Sf.create_ctags, 'create ctag file in project root')
-  nmap('<leader>ft', Sf.create_and_list_ctags, 'fzf list updated ctags')
+  nmap("<leader>ss", Sf.set_target_org, "set target_org current workspace")
+  nmap("<leader>sS", Sf.set_global_target_org, "set global target_org")
+  nmap("<leader>sf", Sf.fetch_org_list, "fetch orgs info")
+  nmap("<leader>ml", Sf.list_md_to_retrieve, "metadata listing")
+  nmap("<leader>mtl", Sf.list_md_type_to_retrieve, "metadata-type listing")
+  nmap("<leader><leader>", Sf.toggle_term, "terminal toggle")
+  nmap("<C-c>", Sf.cancel, "cancel running command")
+  nmap("<leader>s-", Sf.go_to_sf_root, "cd into root")
+  nmap("<leader>ct", Sf.create_ctags, "create ctag file in project root")
+  nmap("<leader>ft", Sf.create_and_list_ctags, "fzf list updated ctags")
   nmap("<leader>so", Sf.org_open, "open target_org")
 
   -- Hotkeys for metadata files only;
   if vim.tbl_contains(vim.g.sf.hotkeys_in_filetypes, vim.bo.filetype) then
     nmap("<leader>sO", Sf.org_open_current_file, "open file in target_org")
-    nmap('<leader>sd', Sf.diff_in_target_org, "diff in target_org")
-    nmap('<leader>sD', Sf.diff_in_org, "diff in org...")
-    nmap('<leader>ma', Sf.retrieve_apex_under_cursor, "apex under cursor retrieve")
-    nmap('<leader>sp', Sf.save_and_push, "push current file")
-    nmap('<leader>sr', Sf.retrieve, "retrieve current file")
+    nmap("<leader>sd", Sf.diff_in_target_org, "diff in target_org")
+    nmap("<leader>sD", Sf.diff_in_org, "diff in org...")
+    nmap("<leader>ma", Sf.retrieve_apex_under_cursor, "apex under cursor retrieve")
+    nmap("<leader>sp", Sf.save_and_push, "push current file")
+    nmap("<leader>sr", Sf.retrieve, "retrieve current file")
 
-    vim.keymap.set('x', '<leader>sq', Sf.run_highlighted_soql, { buffer = true, desc = "SOQL run highlighted text" })
+    vim.keymap.set("x", "<leader>sq", Sf.run_highlighted_soql, { buffer = true, desc = "SOQL run highlighted text" })
 
-    nmap('<leader>ta', Sf.run_all_tests_in_this_file, "test all in this file")
-    nmap('<leader>tA', Sf.run_all_tests_in_this_file_with_coverage, "test all with coverage info")
-    nmap('<leader>tt', Sf.run_current_test, "test this under cursor")
-    nmap('<leader>tT', Sf.run_current_test_with_coverage, "test this under cursor with coverage info")
-    nmap('<leader>to', Sf.open_test_select, "open test select buf")
-    nmap('\\s', Sf.toggle_sign, "toggle signs for code coverage")
-    nmap('<leader>tr', Sf.repeat_last_tests, "repeat last test")
-    nmap('<leader>cc', Sf.copy_apex_name, "copy apex name")
-    nmap('<leader>cc', Sf.copy_apex_name, "copy apex name")
-    nmap('[v', Sf.uncovered_jump_backward, "jump to previous uncovered sign icon line")
-    nmap(']v', Sf.uncovered_jump_forward, "jump to next uncovered sign icon line")
+    nmap("<leader>ta", Sf.run_all_tests_in_this_file, "test all in this file")
+    nmap("<leader>tA", Sf.run_all_tests_in_this_file_with_coverage, "test all with coverage info")
+    nmap("<leader>tt", Sf.run_current_test, "test this under cursor")
+    nmap("<leader>tT", Sf.run_current_test_with_coverage, "test this under cursor with coverage info")
+    nmap("<leader>to", Sf.open_test_select, "open test select buf")
+    nmap("\\s", Sf.toggle_sign, "toggle signs for code coverage")
+    nmap("<leader>tr", Sf.repeat_last_tests, "repeat last test")
+    nmap("<leader>cc", Sf.copy_apex_name, "copy apex name")
+    nmap("<leader>cc", Sf.copy_apex_name, "copy apex name")
+    nmap("[v", Sf.uncovered_jump_backward, "jump to previous uncovered sign icon line")
+    nmap("]v", Sf.uncovered_jump_forward, "jump to next uncovered sign icon line")
   end
 end
 

--- a/lua/sf/sub/raw_term.lua
+++ b/lua/sf/sub/raw_term.lua
@@ -17,10 +17,10 @@ end
 
 function T:setup(cfg)
   if not cfg then
-    return vim.notify('SFTerm: setup() is optional. Please remove it!', vim.log.levels.WARN)
+    return vim.notify("SFTerm: setup() is optional. Please remove it!", vim.log.levels.WARN)
   end
 
-  self.config = vim.tbl_deep_extend('force', self.config, cfg)
+  self.config = vim.tbl_deep_extend("force", self.config, cfg)
 
   return self
 end
@@ -34,7 +34,7 @@ end
 
 function T:run(cmd, cb)
   if self.is_running then
-    return vim.notify('Wait the current task to finish.', vim.log.levels.WARN)
+    return vim.notify("Wait the current task to finish.", vim.log.levels.WARN)
   end
 
   local running_buf = api.nvim_create_buf(false, true)
@@ -99,7 +99,7 @@ function T:open()
   end
 
   if not H.is_buf_valid(self.buf) then
-    return vim.notify_once('Sf: no previous task. Run a termnimal command to initiate the term.', vim.log.levels.WARN)
+    return vim.notify_once("Sf: no previous task. Run a termnimal command to initiate the term.", vim.log.levels.WARN)
   end
 
   local win = self:create_and_open_win(self.buf)
@@ -130,25 +130,25 @@ function T:create_and_open_win(buf)
 
   local win = api.nvim_open_win(buf, false, {
     border = cfg.border,
-    relative = 'editor',
-    style = 'minimal',
-    title = 'SFTerm',
-    title_pos = 'center',
+    relative = "editor",
+    style = "minimal",
+    title = "SFTerm",
+    title_pos = "center",
     width = dim.width,
     height = dim.height,
     col = dim.col,
     row = dim.row,
   })
 
-  api.nvim_win_set_option(win, 'winhl', ('Normal:%s'):format(cfg.hl))
-  api.nvim_win_set_option(win, 'winblend', cfg.blend)
+  api.nvim_win_set_option(win, "winhl", ("Normal:%s"):format(cfg.hl))
+  api.nvim_win_set_option(win, "winblend", cfg.blend)
 
   return win
 end
 
 function T:remember_cursor()
   self.last_win = api.nvim_get_current_win()
-  self.prev_win = vim.fn.winnr('#')
+  self.prev_win = vim.fn.winnr("#")
   self.last_pos = api.nvim_win_get_cursor(self.last_win)
 
   return self
@@ -157,7 +157,7 @@ end
 function T:restore_cursor()
   if self.last_win and self.last_pos ~= nil then
     if self.prev_win > 0 then
-      cmd(('silent! %s wincmd w'):format(self.prev_win))
+      cmd(("silent! %s wincmd w"):format(self.prev_win))
     end
 
     if H.is_win_valid(self.last_win) then
@@ -178,7 +178,7 @@ function T:get_config()
 end
 
 function T:scroll_to_end()
-  cmd('$')
+  cmd("$")
   return self
 end
 

--- a/lua/sf/sub/test_sign.lua
+++ b/lua/sf/sub/test_sign.lua
@@ -1,4 +1,4 @@
-local U = require('sf.util')
+local U = require("sf.util")
 local M = {}
 local H = {}
 local enabled = false
@@ -26,16 +26,16 @@ M.setup = function()
   H.highlight(covered_group, { fg = vim.g.sf.code_sign_highlight.covered.fg })
   H.highlight(uncovered_group, { fg = vim.g.sf.code_sign_highlight.uncovered.fg })
 
-  vim.fn.sign_define(covered_sign, { text = "▎", texthl = covered_group, })
-  vim.fn.sign_define(uncovered_sign, { text = "▎", texthl = uncovered_group, })
+  vim.fn.sign_define(covered_sign, { text = "▎", texthl = covered_group })
+  vim.fn.sign_define(uncovered_sign, { text = "▎", texthl = uncovered_group })
 end
 
 M.toggle = function()
   if enabled then
-    vim.notify('Sign disabled.', vim.log.levels.INFO)
+    vim.notify("Sign disabled.", vim.log.levels.INFO)
     H.unplace()
   else
-    vim.notify('Sign enabled.', vim.log.levels.INFO)
+    vim.notify("Sign enabled.", vim.log.levels.INFO)
     M.refresh_and_place()
   end
 end
@@ -75,7 +75,7 @@ M.refresh_current_file_covered_percent = function()
   local file_name = vim.fn.expand("%:t")
 
   for i, v in pairs(coverage) do
-    local apex_name = v["name"] .. '.cls'
+    local apex_name = v["name"] .. ".cls"
 
     if file_name == apex_name then
       M.covered_percent = v["coveredPercent"]
@@ -98,7 +98,7 @@ H.get_signs_from = function(coverage)
   local signs = {}
 
   for i, v in pairs(coverage) do
-    local apex_name = v["name"] .. '.cls'
+    local apex_name = v["name"] .. ".cls"
 
     if vim.fn.expand("%:t") == apex_name then
       M.covered_percent = v["coveredPercent"]
@@ -135,14 +135,14 @@ H.get_coverage = function()
     return coverage
   end
 
-  local tbl = U.read_file_in_plugin_folder('test_result.json')
+  local tbl = U.read_file_in_plugin_folder("test_result.json")
   if not tbl then
-    return vim.notify_once('Local test_result.json not found.', vim.log.levels.WARN)
+    return vim.notify_once("Local test_result.json not found.", vim.log.levels.WARN)
   end
 
   coverage = vim.tbl_get(tbl, "result", "coverage", "coverage")
   if coverage == nil then
-    return vim.notify_once('Local test_result.json has no coverage element.', vim.log.levels.WARN)
+    return vim.notify_once("Local test_result.json has no coverage element.", vim.log.levels.WARN)
   end
 
   cache = coverage

--- a/lua/sf/term.lua
+++ b/lua/sf/term.lua
@@ -1,5 +1,5 @@
-local U = require('sf.util')
-local B = require('sf.sub.cmd_builder')
+local U = require("sf.util")
+local B = require("sf.sub.cmd_builder")
 local Term = {}
 local H = {}
 local t
@@ -8,7 +8,7 @@ local t
 -- it's meant to delay the raw term initialization so the term_cfg is ready after user's setup() call
 ---@param term_cfg table
 function Term.setup(term_cfg)
-  t = require('sf.sub.raw_term'):new(term_cfg)
+  t = require("sf.sub.raw_term"):new(term_cfg)
 end
 
 function Term.toggle()
@@ -21,106 +21,106 @@ end
 
 function Term.save_and_push()
   if U.is_empty_str(U.target_org) then
-    return U.show_err('Target_org empty!')
+    return U.show_err("Target_org empty!")
   end
   -- vim.api.nvim_command('e') -- reload file to avoid invoking y/n pop-up in Ex
-  vim.api.nvim_command('write!')
+  vim.api.nvim_command("write!")
   -- local cmd = vim.fn.expandcmd('sf project deploy start -d "%:p" -o ') .. U.get()
-  local cmd = B:new():cmd('project'):act('deploy start'):addParams('-d', '%:p'):build()
+  local cmd = B:new():cmd("project"):act("deploy start"):addParams("-d", "%:p"):build()
   t:run(cmd)
 end
 
 function Term.push_delta()
   if U.is_empty_str(U.target_org) then
-    return U.show_err('Target_org empty!')
+    return U.show_err("Target_org empty!")
   end
   -- local cmd = vim.fn.expandcmd('sf project deploy start -o ') .. U.get()
-  local cmd = B:new():cmd('project'):act('deploy start'):build()
+  local cmd = B:new():cmd("project"):act("deploy start"):build()
   t:run(cmd)
 end
 
 function Term.retrieve()
   if U.is_empty_str(U.target_org) then
-    return U.show_err('Target_org empty!')
+    return U.show_err("Target_org empty!")
   end
   -- local cmd = vim.fn.expandcmd('sf project retrieve start -d "%:p" -o ') .. U.get()
-  local cmd = B:new():cmd('project'):act('retrieve start'):addParams('-d', '%:p'):build()
+  local cmd = B:new():cmd("project"):act("retrieve start"):addParams("-d", "%:p"):build()
   t:run(cmd)
 end
 
 function Term.retrieve_delta()
   if U.is_empty_str(U.target_org) then
-    return U.show_err('Target_org empty!')
+    return U.show_err("Target_org empty!")
   end
   -- local cmd = vim.fn.expandcmd('sf project retrieve start -o ') .. U.get()
-  local cmd = B:new():cmd('project'):act('retrieve start'):build()
+  local cmd = B:new():cmd("project"):act("retrieve start"):build()
   t:run(cmd)
 end
 
 function Term.retrieve_package()
   if U.is_empty_str(U.target_org) then
-    return U.show_err('Target_org empty!')
+    return U.show_err("Target_org empty!")
   end
   -- local cmd = vim.fn.expandcmd('sf project retrieve start -x "%:p" -o ') .. U.get()
-  local cmd = B:new():cmd('project'):act('retrieve start'):addParams('-x', '%:p'):build()
+  local cmd = B:new():cmd("project"):act("retrieve start"):addParams("-x", "%:p"):build()
   t:run(cmd)
 end
 
 function Term.run_anonymous()
   if U.is_empty_str(U.target_org) then
-    return U.show_err('Target_org empty!')
+    return U.show_err("Target_org empty!")
   end
   -- local cmd = vim.fn.expandcmd('sf apex run -f "%:p" -o ') .. U.get()
-  local cmd = B:new():cmd('apex'):act('run'):addParams('-f', '%:p'):build()
+  local cmd = B:new():cmd("apex"):act("run"):addParams("-f", "%:p"):build()
   t:run(cmd)
 end
 
 function Term.run_query()
   if U.is_empty_str(U.target_org) then
-    return U.show_err('Target_org empty!')
+    return U.show_err("Target_org empty!")
   end
   -- local cmd = vim.fn.expandcmd('sf data query -w 5 -f "%:p" -o ') .. U.get()
-  local cmd = B:new():cmd('data'):act('query'):addParams('-w', 5):addParams('-f', '%:p'):build()
+  local cmd = B:new():cmd("data"):act("query"):addParams("-w", 5):addParams("-f", "%:p"):build()
   t:run(cmd)
 end
 
 function Term.run_tooling_query()
   if U.is_empty_str(U.target_org) then
-    return U.show_err('Target_org empty!')
+    return U.show_err("Target_org empty!")
   end
   -- local cmd = vim.fn.expandcmd('sf data query -t -w 5 -f "%:p" -o ') .. U.get()
-  local cmd = B:new():cmd('data'):act('query'):addParams({ ['-w'] = 5, ['-f'] = '%:p', ['-t'] = '' }):build()
+  local cmd = B:new():cmd("data"):act("query"):addParams({ ["-w"] = 5, ["-f"] = "%:p", ["-t"] = "" }):build()
   t:run(cmd)
 end
 
 function Term.run_highlighted_soql()
   if U.is_empty_str(U.target_org) then
-    return U.show_err('Target_org empty!')
+    return U.show_err("Target_org empty!")
   end
-  if vim.fn.mode() ~= 'v' then
-    vim.notify('Not in normal visual mode per character.', vim.log.levels.WARN);
+  if vim.fn.mode() ~= "v" then
+    vim.notify("Not in normal visual mode per character.", vim.log.levels.WARN)
     return
   end
 
   local selected_text = H.get_visual_selection()
   if not selected_text then
-    vim.notify('Empty selection.', vim.log.levels.WARN);
+    vim.notify("Empty selection.", vim.log.levels.WARN)
   end
 
   -- local raw_cmd = string.format('sf data query -q "%s" -o %s', selected_text, U.get())
-  local raw_cmd = B:new():cmd('data'):act('query'):addParams('-q', selected_text):build()
-  local cmd = string.gsub(raw_cmd, "'", "\'")
+  local raw_cmd = B:new():cmd("data"):act("query"):addParams("-q", selected_text):build()
+  local cmd = string.gsub(raw_cmd, "'", "'")
   t:run(cmd)
 end
 
 function Term.cancel()
   t.is_running = false -- set the flag to stop the running task
-  t:run('\3')
+  t:run("\3")
 end
 
 function Term.go_to_sf_root()
   local root = U.get_sf_root()
-  t:run('cd ' .. root)
+  t:run("cd " .. root)
 end
 
 function Term.run(cmd, cb)
@@ -143,7 +143,7 @@ H.get_visual_selection = function()
   vim.cmd('noautocmd normal! "vy"')
 
   -- Get the content of the unnamed register (which now contains our selection)
-  local selection = vim.fn.getreg('v')
+  local selection = vim.fn.getreg("v")
 
   -- Restore the register to its previous state
   vim.fn.setreg('"', old_reg, old_regtype)

--- a/lua/sf/test.lua
+++ b/lua/sf/test.lua
@@ -1,8 +1,8 @@
-local T = require('sf.term')
-local B = require('sf.sub.cmd_builder')
-local TS = require('sf.ts')
-local U = require('sf.util')
-local S = require('sf.sub.test_sign')
+local T = require("sf.term")
+local B = require("sf.sub.cmd_builder")
+local TS = require("sf.ts")
+local U = require("sf.util")
+local S = require("sf.sub.test_sign")
 
 local H = {}
 local P = {}
@@ -34,12 +34,16 @@ Test.run_current_test_with_coverage = function()
     return
   end
 
-  local cmd = B:new():cmd('apex'):act('run test'):addParams({
-    ['-t'] = test_class_name .. '.' .. test_name,
-    ['-r'] = 'human',
-    ['-w'] = '5',
-    ['-c'] = '',
-  }):build()
+  local cmd = B:new()
+    :cmd("apex")
+    :act("run test")
+    :addParams({
+      ["-t"] = test_class_name .. "." .. test_name,
+      ["-r"] = "human",
+      ["-w"] = "5",
+      ["-c"] = "",
+    })
+    :build()
 
   U.last_tests = cmd
   T.run(cmd, H.save_test_coverage_locally)
@@ -59,11 +63,15 @@ Test.run_current_test = function()
   end
 
   -- local cmd = string.format("sf apex run test --tests %s.%s -r human -w 5 %s-o %s", test_class_name, test_name, extraParams, U.get())
-  local cmd = B:new():cmd('apex'):act('run test'):addParams({
-    ['-t'] = test_class_name .. '.' .. test_name,
-    ['-r'] = 'human',
-    ['-w'] = '5',
-  }):build()
+  local cmd = B:new()
+    :cmd("apex")
+    :act("run test")
+    :addParams({
+      ["-t"] = test_class_name .. "." .. test_name,
+      ["-r"] = "human",
+      ["-w"] = "5",
+    })
+    :build()
 
   U.last_tests = cmd
   T.run(cmd)
@@ -75,12 +83,16 @@ Test.run_all_tests_in_this_file_with_coverage = function()
     return
   end
 
-  local cmd = B:new():cmd('apex'):act('run test'):addParams({
-    ['-n'] = test_class_name,
-    ['-r'] = 'human',
-    ['-w'] = '5',
-    ['-c'] = '',
-  }):build()
+  local cmd = B:new()
+    :cmd("apex")
+    :act("run test")
+    :addParams({
+      ["-n"] = test_class_name,
+      ["-r"] = "human",
+      ["-w"] = "5",
+      ["-c"] = "",
+    })
+    :build()
 
   U.last_tests = cmd
   T.run(cmd, H.save_test_coverage_locally)
@@ -95,11 +107,15 @@ Test.run_all_tests_in_this_file = function(cb)
   end
 
   -- local cmd = string.format("sf apex run test --class-names %s -r human -w 5 %s-o %s", test_class_name, extraParams, U.get())
-  local cmd = B:new():cmd('apex'):act('run test'):addParams({
-    ['-n'] = test_class_name,
-    ['-r'] = 'human',
-    ['-w'] = '5',
-  }):build()
+  local cmd = B:new()
+    :cmd("apex")
+    :act("run test")
+    :addParams({
+      ["-n"] = test_class_name,
+      ["-r"] = "human",
+      ["-w"] = "5",
+    })
+    :build()
 
   U.last_tests = cmd
   T.run(cmd, cb)
@@ -107,7 +123,7 @@ end
 
 Test.repeat_last_tests = function()
   if U.is_empty_str(U.last_tests) then
-    return U.show_warn('Last test command is empty.')
+    return U.show_warn("Last test command is empty.")
   end
 
   T.run(U.last_tests)
@@ -115,27 +131,31 @@ end
 
 Test.run_local_tests = function()
   -- local cmd = string.format("sf apex run test --test-level RunLocalTests --code-coverage -r human --wait 180 -o %s", U.get())
-  local cmd = B:new():cmd('apex'):act('run test'):addParams({
-    ['-l'] = 'RunLocalTests',
-    ['-c'] = '',
-    ['-r'] = 'human',
-    ['-w'] = 180,
-  }):build()
+  local cmd = B:new()
+    :cmd("apex")
+    :act("run test")
+    :addParams({
+      ["-l"] = "RunLocalTests",
+      ["-c"] = "",
+      ["-r"] = "human",
+      ["-w"] = 180,
+    })
+    :build()
 
   U.last_tests = cmd
   T.run(cmd)
 end
 
 Test.run_all_jests = function()
-    T.run('npm run test:unit:coverage')
+  T.run("npm run test:unit:coverage")
 end
 
 Test.run_jest_file = function()
-    if vim.fn.expand('%'):match('(.*)%.test%.js$') == nil then
-        vim.notify('Not in a jest test file', vim.log.levels.ERROR)
-        return
-    end
-    T.run(string.format('npm run test:unit -- -- %s', vim.fn.expand('%')))
+  if vim.fn.expand("%"):match("(.*)%.test%.js$") == nil then
+    vim.notify("Not in a jest test file", vim.log.levels.ERROR)
+    return
+  end
+  T.run(string.format("npm run test:unit -- -- %s", vim.fn.expand("%")))
 end
 
 -- helper;
@@ -143,7 +163,7 @@ end
 H.validateInTestClass = function()
   local test_class_name = TS.get_test_class_name()
   if U.is_empty_str(test_class_name) then
-    U.notify_then_error('Not in a test class.')
+    U.notify_then_error("Not in a test class.")
   end
 
   return test_class_name
@@ -152,7 +172,7 @@ end
 H.validateInTestMethod = function()
   local test_name = TS.get_current_test_method_name()
   if U.is_empty_str(test_name) then
-    U.notify_then_error('Cursor not in a test method.')
+    U.notify_then_error("Cursor not in a test method.")
   end
 
   return test_name
@@ -183,8 +203,8 @@ H.save_test_coverage_locally = function(self, cmd, exit_code)
 
   local file_name = "test_result.json"
   -- local cmd = 'sf apex get test -i ' .. id .. ' -c --json > ' .. U.get_plugin_folder_path() .. file_name
-  local cmd = B:new():cmd('apex'):act('get test'):addParams('-i', id):addParams('-c'):addParams('--json'):build()
-  cmd = cmd .. ' > ' .. U.get_plugin_folder_path() .. file_name
+  local cmd = B:new():cmd("apex"):act("get test"):addParams("-i", id):addParams("-c"):addParams("--json"):build()
+  cmd = cmd .. " > " .. U.get_plugin_folder_path() .. file_name
 
   U.silent_job_call(cmd, "Code coverage saved.", "Code coverage save failed! " .. cmd, S.invalidate_cache_and_try_place)
 end
@@ -192,8 +212,8 @@ end
 -- prompt below
 
 local api = vim.api
-local buftype = 'nowrite'
-local filetype = 'sf_test_prompt'
+local buftype = "nowrite"
+local filetype = "sf_test_prompt"
 
 P.buf = nil
 P.win = nil
@@ -205,12 +225,12 @@ P.selected_tests = {}
 P.open = function()
   local class = TS.get_test_class_name()
   if U.is_empty_str(class) then
-    U.notify_then_error('Not an Apex test class.')
+    U.notify_then_error("Not an Apex test class.")
   end
 
   local test_names = TS.get_test_method_names_in_curr_file()
   if vim.tbl_isempty(test_names) then
-    U.show('no Apex test found.')
+    U.show("no Apex test found.")
   end
 
   local tests = {}
@@ -239,16 +259,16 @@ P.open = function()
 end
 
 P.set_keys = function()
-  vim.keymap.set('n', 'x', function()
+  vim.keymap.set("n", "x", function()
     P.toggle()
   end, { buffer = true, noremap = true })
 
   local create_cmd = function(tbl)
-    local cmd_builder = B:new():cmd('apex'):act('run test'):addParams(tbl)
+    local cmd_builder = B:new():cmd("apex"):act("run test"):addParams(tbl)
 
-    local test_params = ''
+    local test_params = ""
     for _, test in ipairs(P.selected_tests) do
-      test_params = test_params .. ' -t ' .. test
+      test_params = test_params .. " -t " .. test
     end
 
     local cmd = cmd_builder:addParamStr(test_params):build()
@@ -256,12 +276,12 @@ P.set_keys = function()
     return cmd
   end
 
-  vim.keymap.set('n', 'cc', function()
+  vim.keymap.set("n", "cc", function()
     if vim.tbl_isempty(P.selected_tests) then
-      return U.show_err('No test is selected.')
+      return U.show_err("No test is selected.")
     end
 
-    local cmd = create_cmd({ ['-w'] = '5', ['-r'] = 'human' })
+    local cmd = create_cmd({ ["-w"] = "5", ["-r"] = "human" })
 
     P.close()
     T.run(cmd)
@@ -269,12 +289,12 @@ P.set_keys = function()
     P.selected_tests = {}
   end, { buffer = true, noremap = true })
 
-  vim.keymap.set('n', 'CC', function()
+  vim.keymap.set("n", "CC", function()
     if vim.tbl_isempty(P.selected_tests) then
-      return U.show_err('No test is selected.')
+      return U.show_err("No test is selected.")
     end
 
-    local cmd = create_cmd({ ['-w'] = '5', ['-r'] = 'human', ['-c'] = '' })
+    local cmd = create_cmd({ ["-w"] = "5", ["-r"] = "human", ["-c"] = "" })
 
     P.close()
     T.run(cmd, H.save_test_coverage_locally)
@@ -286,15 +306,14 @@ end
 P.display = function()
   api.nvim_set_current_win(P.win)
   local names = {}
-  table.insert(names,
-    '** "x": toggle tests; "cc": run tests; "CC": run tests with code coverage.')
+  table.insert(names, '** "x": toggle tests; "cc": run tests; "CC": run tests with code coverage.')
 
   for _, test in ipairs(P.tests) do
-    local class_test = string.format('%s.%s', P.class, test)
+    local class_test = string.format("%s.%s", P.class, test)
     if vim.tbl_contains(P.selected_tests, class_test) then
-      table.insert(names, '[x] ' .. test)
+      table.insert(names, "[x] " .. test)
     else
-      table.insert(names, '[ ] ' .. test)
+      table.insert(names, "[ ] " .. test)
     end
   end
   api.nvim_buf_set_lines(P.buf, 0, 100, false, names)
@@ -321,14 +340,14 @@ P.use_existing_or_create_win = function()
     return P.win
   end
 
-  api.nvim_command(win_hight .. 'split')
+  api.nvim_command(win_hight .. "split")
 
   return api.nvim_get_current_win()
 end
 
 P.toggle = function()
   if vim.bo[0].filetype ~= filetype then
-    return U.show_err('file-type must be: ' .. filetype)
+    return U.show_err("file-type must be: " .. filetype)
   end
 
   vim.bo[0].modifiable = true
@@ -343,22 +362,22 @@ P.toggle = function()
   local curr_value = api.nvim_buf_get_text(0, row_index, 1, row_index, 2, {})
 
   local name = P.tests[row_index]
-  local class_test = string.format('%s.%s', P.class, name)
+  local class_test = string.format("%s.%s", P.class, name)
   local index = U.list_find(P.selected_tests, class_test)
 
-  if curr_value[1] == 'x' then
+  if curr_value[1] == "x" then
     if index ~= nil then
       table.remove(P.selected_tests, index)
     end
-    api.nvim_buf_set_text(0, row_index, 1, row_index, 2, { ' ' })
-  elseif curr_value[1] == ' ' then
+    api.nvim_buf_set_text(0, row_index, 1, row_index, 2, { " " })
+  elseif curr_value[1] == " " then
     if index == nil then
       table.insert(P.selected_tests, class_test)
     end
-    api.nvim_buf_set_text(0, row_index, 1, row_index, 2, { 'x' })
+    api.nvim_buf_set_text(0, row_index, 1, row_index, 2, { "x" })
   end
 
-  U.show('Selected: ' .. vim.tbl_count(P.selected_tests))
+  U.show("Selected: " .. vim.tbl_count(P.selected_tests))
 
   vim.bo[0].modifiable = false
 end

--- a/lua/sf/ts.lua
+++ b/lua/sf/ts.lua
@@ -1,5 +1,5 @@
 local ts = vim.treesitter
-local parsers = require('nvim-treesitter.parsers')
+local parsers = require("nvim-treesitter.parsers")
 
 local M = {}
 local H = {}
@@ -67,7 +67,7 @@ M.get_current_test_method_name = function()
 
   local curr_node = ts.get_node()
   while curr_node ~= nil do
-    if curr_node:type() == 'method_declaration' then
+    if curr_node:type() == "method_declaration" then
       local names = H.get_matched_node_names(apex_test_meth_query, 2, curr_node)
       if names ~= nil then
         return names[1]

--- a/lua/sf/util.lua
+++ b/lua/sf/util.lua
@@ -1,21 +1,21 @@
 local M = {}
 
-M.last_tests = ''
-M.target_org = ''
+M.last_tests = ""
+M.target_org = ""
 
 ---@param msg string
 M.show = function(msg)
-  vim.notify(msg, vim.log.levels.INFO, { title = 'sf.nvim' })
+  vim.notify(msg, vim.log.levels.INFO, { title = "sf.nvim" })
 end
 
 ---@param msg string
 M.show_err = function(msg)
-  vim.notify(msg, vim.log.levels.ERROR, { title = 'sf.nvim' })
+  vim.notify(msg, vim.log.levels.ERROR, { title = "sf.nvim" })
 end
 
 ---@param msg string
 M.show_warn = function(msg)
-  vim.notify(msg, vim.log.levels.WARN, { title = 'sf.nvim' })
+  vim.notify(msg, vim.log.levels.WARN, { title = "sf.nvim" })
 end
 
 ---@param msg string
@@ -27,7 +27,7 @@ end
 
 M.get = function()
   if M.is_empty_str(M.target_org) then
-    error('Sf: Target_org empty!')
+    error("Sf: Target_org empty!")
   end
 
   return M.target_org
@@ -35,27 +35,27 @@ end
 
 M.get_default_dir_path = function()
   local dir_path = M.get_sf_root() .. vim.g.sf.default_dir
-    if (dir_path:sub(1,1) ~= "/" and dir_path:sub(1,1) ~= ".") then
-        dir_path = "/" .. dir_path
-    end
-    if (dir_path:sub(-1) ~= "/") then
-        dir_path = dir_path .. "/"
-    end
+  if dir_path:sub(1, 1) ~= "/" and dir_path:sub(1, 1) ~= "." then
+    dir_path = "/" .. dir_path
+  end
+  if dir_path:sub(-1) ~= "/" then
+    dir_path = dir_path .. "/"
+  end
   return dir_path
 end
 
 M.get_apex_folder_path = function()
-  return M.get_default_dir_path() .. 'classes/'
+  return M.get_default_dir_path() .. "classes/"
 end
 
 M.get_plugin_folder_path = function()
-    local folder_path = M.get_sf_root() .. vim.g.sf.plugin_folder_name
-    if (folder_path:sub(1,1) ~= "/" and folder_path:sub(1,1) ~= ".") then
-        folder_path = "/" .. folder_path
-    end
-    if (folder_path:sub(-1) ~= "/") then
-        folder_path = folder_path .. "/"
-    end
+  local folder_path = M.get_sf_root() .. vim.g.sf.plugin_folder_name
+  if folder_path:sub(1, 1) ~= "/" and folder_path:sub(1, 1) ~= "." then
+    folder_path = "/" .. folder_path
+  end
+  if folder_path:sub(-1) ~= "/" then
+    folder_path = folder_path .. "/"
+  end
   return folder_path
 end
 
@@ -64,7 +64,7 @@ M.create_plugin_folder_if_not_exist = function()
   if vim.fn.isdirectory(cache_folder) == 0 then
     local result = vim.fn.mkdir(cache_folder)
     if result == 0 then
-      return vim.notify('cache folder creation failed!', vim.log.levels.ERROR)
+      return vim.notify("cache folder creation failed!", vim.log.levels.ERROR)
     end
   end
 end
@@ -86,7 +86,7 @@ M.get_sf_root = function()
   })[1])
 
   if root == nil then
-    error('File not in a sf project folder')
+    error("File not in a sf project folder")
   end
 
   if root:sub(-1) ~= "/" then
@@ -97,28 +97,28 @@ M.get_sf_root = function()
 end
 
 M.is_sf_cmd_installed = function()
-  if vim.fn.executable('sf') ~= 1 then
-    M.notify_then_error('sf cli not found')
+  if vim.fn.executable("sf") ~= 1 then
+    M.notify_then_error("sf cli not found")
   end
 end
 
 M.is_ctags_installed = function()
-  if vim.fn.executable('ctags') ~= 1 then
-    M.notify_then_error('ctags cli not found')
+  if vim.fn.executable("ctags") ~= 1 then
+    M.notify_then_error("ctags cli not found")
   end
 end
 
 ---@param tbl table
 M.is_table_empty = function(tbl)
   if vim.tbl_isempty(tbl) then
-    M.notify_then_error('Empty table')
+    M.notify_then_error("Empty table")
   end
 end
 
 ---@param s string|nil
 ---@return boolean
 M.is_empty_str = function(s)
-  return s == nil or s == ''
+  return s == nil or s == ""
 end
 
 ---@param tbl table
@@ -139,18 +139,17 @@ end
 M.silent_job_call = function(cmd, msg, err_msg, cb)
   vim.fn.jobstart(cmd, {
     stdout_buffered = true,
-    on_exit =
-        function(_, code)
-          if code == 0 and msg ~= nil then
-            vim.notify(msg, vim.log.levels.INFO)
-          elseif code ~= 0 and err_msg ~= nil then
-            vim.notify(err_msg, vim.log.levels.ERROR)
-          end
+    on_exit = function(_, code)
+      if code == 0 and msg ~= nil then
+        vim.notify(msg, vim.log.levels.INFO)
+      elseif code ~= 0 and err_msg ~= nil then
+        vim.notify(err_msg, vim.log.levels.ERROR)
+      end
 
-          if code == 0 and cb ~= nil then
-            cb()
-          end
-        end,
+      if code == 0 and cb ~= nil then
+        cb()
+      end
+    end,
   })
 end
 
@@ -159,14 +158,14 @@ end
 ---@param err_msg string|nil
 ---@param cb function|nil
 M.job_call = function(cmd, msg, err_msg, cb)
-  vim.notify('| Async job starts...', vim.log.levels.INFO);
+  vim.notify("| Async job starts...", vim.log.levels.INFO)
   M.silent_job_call(cmd, msg, err_msg, cb)
 end
 
 -- Copy current file name without dot-after, e.g. copy "Hello" from "Hello.cls"
 M.copy_apex_name = function()
   local file_name = vim.split(vim.fn.expand("%:t"), ".", { trimempty = true, plain = true })[1]
-  vim.fn.setreg('*', file_name)
+  vim.fn.setreg("*", file_name)
   vim.notify(string.format('"%s" copied.', file_name), vim.log.levels.INFO)
 end
 
@@ -177,16 +176,13 @@ M.run_cb_with_input = function(arg, prompt, cb)
   if arg ~= nil then
     cb(arg)
   else
-    vim.ui.input(
-      { prompt = prompt },
-      function(input)
-        if input ~= nil then
-          cb(input)
-        else
-          return
-        end
+    vim.ui.input({ prompt = prompt }, function(input)
+      if input ~= nil then
+        cb(input)
+      else
+        return
       end
-    )
+    end)
   end
 end
 
@@ -221,7 +217,7 @@ end
 M.read_file_json_to_tbl = function(name, path)
   local absolute_path = path .. name
   local err_fn = function()
-    vim.notify_once('File not found: ' .. absolute_path, vim.log.levels.WARN)
+    vim.notify_once("File not found: " .. absolute_path, vim.log.levels.WARN)
   end
   local content = M.read_local_file(absolute_path, err_fn)
   if content == nil then
@@ -242,7 +238,7 @@ M.read_local_file = function(absolute_path, err_fn)
     if type(err_fn) == "function" then
       return err_fn()
     else
-      M.notify_then_error('File not found: ' .. absolute_path)
+      M.notify_then_error("File not found: " .. absolute_path)
     end
   end
 
@@ -255,7 +251,7 @@ M.parse_from_json_to_tbl = function(content)
   local json = table.concat(content)
   local ok, tbl = pcall(vim.json.decode, json, {})
   if not ok then
-    M.notify_then_error('Parse file from json to tbl failed: ' .. absolute_path)
+    M.notify_then_error("Parse file from json to tbl failed: " .. absolute_path)
   end
 
   return tbl
@@ -306,12 +302,12 @@ end
 
 -- this func is supposed to be only manually called by the plugin developer to generate plugin help.txt
 M.gen_doc = function()
-  if not M.is_installed('mini.doc') then
-    M.notify_then_error('mini.doc not installed.')
+  if not M.is_installed("mini.doc") then
+    M.notify_then_error("mini.doc not installed.")
   end
 
-  require('mini.doc').generate({
-    'lua/sf/init.lua'
+  require("mini.doc").generate({
+    "lua/sf/init.lua",
   })
 end
 

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -1,8 +1,8 @@
 vim.cmd([[let &rtp.=','.getcwd()]])
 
 if #vim.api.nvim_list_uis() == 0 then
-  vim.cmd('set rtp+=deps/mini.nvim')
-  require('mini.test').setup()
+  vim.cmd("set rtp+=deps/mini.nvim")
+  require("mini.test").setup()
 end
 
-vim.cmd('set rtp+=deps/nvim-treesitter')
+vim.cmd("set rtp+=deps/nvim-treesitter")

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -2,57 +2,59 @@ local Helpers = {}
 
 Helpers.expect = vim.deepcopy(MiniTest.expect)
 
-Helpers.expect.match = MiniTest.new_expectation(
-  'string matching',
-  function(str, pattern) return str:find(pattern) ~= nil end,
-  function(str, pattern) return string.format('Pattern: %s\nObserved string: %s', vim.inspect(pattern), str) end
-)
+Helpers.expect.match = MiniTest.new_expectation("string matching", function(str, pattern)
+  return str:find(pattern) ~= nil
+end, function(str, pattern)
+  return string.format("Pattern: %s\nObserved string: %s", vim.inspect(pattern), str)
+end)
 
-Helpers.expect.no_match = MiniTest.new_expectation(
-  'no string matching',
-  function(str, pattern) return str:find(pattern) == nil end,
-  function(str, pattern) return string.format('Pattern: %s\nObserved string: %s', vim.inspect(pattern), str) end
-)
+Helpers.expect.no_match = MiniTest.new_expectation("no string matching", function(str, pattern)
+  return str:find(pattern) == nil
+end, function(str, pattern)
+  return string.format("Pattern: %s\nObserved string: %s", vim.inspect(pattern), str)
+end)
 
 Helpers.new_child_neovim = function()
   local child = MiniTest.new_child_neovim()
 
   local prevent_hanging = function(method)
-    if not child.is_blocked() then return end
+    if not child.is_blocked() then
+      return
+    end
 
-    local msg = string.format('Can not use `child.%s` because child process is blocked.', method)
+    local msg = string.format("Can not use `child.%s` because child process is blocked.", method)
     error(msg)
   end
 
   child.setup = function()
-    child.restart({ '-u', 'scripts/minimal_init.lua' })
+    child.restart({ "-u", "scripts/minimal_init.lua" })
     child.bo.readonly = false
   end
 
   child.sf_setup = function(config)
-    local req_cmd = ([[require('sf').setup(...)]])
+    local req_cmd = [[require('sf').setup(...)]]
     child.lua(req_cmd, { config })
   end
 
   child.open_in_sf_dir = function(file)
-    local lua_cmd = string.format('edit tests/dir/sf-project/%s', file)
+    local lua_cmd = string.format("edit tests/dir/sf-project/%s", file)
     child.cmd(lua_cmd)
   end
 
   child.go_to_sf_dir = function()
-    child.cmd('cd tests/dir/sf-project/')
+    child.cmd("cd tests/dir/sf-project/")
   end
 
   child.go_to_non_sf_dir = function()
-    child.cmd('cd tests/dir/non-sf-project/')
+    child.cmd("cd tests/dir/non-sf-project/")
   end
 
   child.go_to_sf_sub_dir = function()
-    child.cmd('cd tests/dir/sf-project/sf_cache/')
+    child.cmd("cd tests/dir/sf-project/sf_cache/")
   end
 
   child.open_in_non_sf_dir = function(file)
-    local lua_cmd = string.format('edit tests/dir/non-sf-project/%s', file)
+    local lua_cmd = string.format("edit tests/dir/non-sf-project/%s", file)
     child.cmd(lua_cmd)
   end
 

--- a/tests/mock/mock.lua
+++ b/tests/mock/mock.lua
@@ -1,2 +1,4 @@
-vim.lsp.buf_get_clients = function() return { 'mock client' } end
+vim.lsp.buf_get_clients = function()
+  return { "mock client" }
+end
 -- vim.fn.jobstart()

--- a/tests/test_cmd_builder.lua
+++ b/tests/test_cmd_builder.lua
@@ -1,4 +1,4 @@
-local helpers = dofile('tests/helpers.lua')
+local helpers = dofile("tests/helpers.lua")
 local child = helpers.new_child_neovim()
 local expect, eq = helpers.expect, helpers.expect.equality
 local new_set = MiniTest.new_set
@@ -16,121 +16,128 @@ local T = new_set({
   },
 })
 
-T['setup()'] = new_set()
+T["setup()"] = new_set()
 
-T['setup()']['can set root command in new()'] = function()
+T["setup()"]["can set root command in new()"] = function()
   local result = child.lua_get('B:new("root"):cmd("org"):act("create shape"):build()')
   local expected = 'root org create shape -o "t_org"'
   eq(result, expected)
 end
 
-T['setup()']['when both "cmd, act" are given then command building success'] = function()
+T["setup()"]['when both "cmd, act" are given then command building success'] = function()
   local result = child.lua_get('B:new():cmd("org"):act("create shape"):build()')
   local expected = 'sf org create shape -o "t_org"'
   eq(result, expected)
 end
 
-T['setup()']['when no "command" property then should throw'] = function()
-  expect.error(function() child.lua([[B:new():act("create shape"):build()]]) end)
+T["setup()"]['when no "command" property then should throw'] = function()
+  expect.error(function()
+    child.lua([[B:new():act("create shape"):build()]])
+  end)
 end
 
-T['setup()']['when no "action" property then should throw'] = function()
-  expect.error(function() child.lua([[B:new():cmd("apex"):build()]]) end)
+T["setup()"]['when no "action" property then should throw'] = function()
+  expect.error(function()
+    child.lua([[B:new():cmd("apex"):build()]])
+  end)
 end
 
-T['setup()']['can supply flag:value string in addParams()'] = function()
+T["setup()"]["can supply flag:value string in addParams()"] = function()
   local result = child.lua_get('B:new():cmd("apex"):act("run"):addParams("-f", "/path/"):build()')
   local expected = 'sf apex run -f "/path/" -o "t_org"'
   eq(result, expected)
 end
 
-T['setup()']['can supply flag:value string in more than one addParams()'] = function()
+T["setup()"]["can supply flag:value string in more than one addParams()"] = function()
   local result = child.lua_get('B:new():cmd("apex"):act("run"):addParams("-f", "/path/"):addParams("-c", "cc"):build()')
   local expected = 'sf apex run -c "cc" -f "/path/" -o "t_org"'
   eq(result, expected)
 end
 
-T['setup()']['when supply number param value it turns into string type in cmd'] = function()
+T["setup()"]["when supply number param value it turns into string type in cmd"] = function()
   local result = child.lua_get('B:new():cmd("apex"):act("run"):addParams("-c", 5):build()')
   local expected = 'sf apex run -c "5" -o "t_org"'
   eq(result, expected)
 end
 
-T['setup()']['can supply table {flag = value} in addParams()'] = function()
+T["setup()"]["can supply table {flag = value} in addParams()"] = function()
   local result = child.lua_get('B:new():cmd("apex"):act("run"):addParams({["-f"] = "/path/"}):build()')
   local expected = 'sf apex run -f "/path/" -o "t_org"'
   eq(result, expected)
 end
 
-T['setup()']['can supply mutliple params in table in addParams()'] = function()
+T["setup()"]["can supply mutliple params in table in addParams()"] = function()
   local result = child.lua_get('B:new():cmd("apex"):act("run"):addParams({["-c"] = "test", ["-f"] = "/path/"}):build()')
   local expected = 'sf apex run -c "test" -f "/path/" -o "t_org"'
   eq(result, expected)
 end
 
-T['setup()']['can sort params with value alphabetically'] = function()
+T["setup()"]["can sort params with value alphabetically"] = function()
   local result = child.lua_get(
-    'B:new():cmd("apex"):act("run"):addParams({["-f"] = "/path/", ["-c"] = "test", ["-t"] = "" }):build()')
+    'B:new():cmd("apex"):act("run"):addParams({["-f"] = "/path/", ["-c"] = "test", ["-t"] = "" }):build()'
+  )
   local expected = 'sf apex run -c "test" -f "/path/" -t -o "t_org"'
   eq(result, expected)
 end
 
-T['setup()']['params without value are put to the end of built command'] = function()
+T["setup()"]["params without value are put to the end of built command"] = function()
   local result = child.lua_get('B:new():cmd("apex"):act("run"):addParams({["-z"] = "", ["-c"] = "test"}):build()')
   local expected = 'sf apex run -c "test" -z -o "t_org"'
   eq(result, expected)
 end
 
-T['setup()']['sorted params with value, then sorted params without value'] = function()
+T["setup()"]["sorted params with value, then sorted params without value"] = function()
   local result = child.lua_get(
-    'B:new():cmd("apex"):act("run"):addParams({["-f"] = "/path/", ["-c"] = "test", ["-z"] = "", ["-t"] = "" }):build()')
+    'B:new():cmd("apex"):act("run"):addParams({["-f"] = "/path/", ["-c"] = "test", ["-z"] = "", ["-t"] = "" }):build()'
+  )
   local expected = 'sf apex run -c "test" -f "/path/" -t -z -o "t_org"'
   eq(result, expected)
 end
 
-T['setup()']['can overwrite with new org value'] = function()
-  local result = child.lua_get(
-    'B:new():cmd("apex"):act("run"):set_org("new_org"):build()')
+T["setup()"]["can overwrite with new org value"] = function()
+  local result = child.lua_get('B:new():cmd("apex"):act("run"):set_org("new_org"):build()')
   local expected = 'sf apex run -o "new_org"'
   eq(result, expected)
 end
 
-T['setup()']['throws when no default_org nor set_org() called'] = function()
-  child.lua('U.target_org = nil')
-  expect.error(function() child.lua([[B:new():cmd("apex"):act("run"):build()]]) end)
+T["setup()"]["throws when no default_org nor set_org() called"] = function()
+  child.lua("U.target_org = nil")
+  expect.error(function()
+    child.lua([[B:new():cmd("apex"):act("run"):build()]])
+  end)
 end
 
-T['setup()']['when no "org" property then use the default targe"t_org"'] = function()
+T["setup()"]['when no "org" property then use the default targe"t_org"'] = function()
   local result = child.lua_get('B:new():cmd("apex"):act("run"):build()')
   local expected = 'sf apex run -o "t_org"'
   eq(result, expected)
 end
 
-T['setup()']['%:p for file_path in param value is expanded'] = function()
-  child.open_in_sf_dir('test.txt')
+T["setup()"]["%:p for file_path in param value is expanded"] = function()
+  child.open_in_sf_dir("test.txt")
   local file_path = child.lua_get('vim.fn.expandcmd("%:p")')
   local result = child.lua_get([[B:new():cmd("apex"):act("run"):addParams("-f", '%:p'):build()]])
   local expected = string.format('sf apex run -f "%s" -o "t_org"', file_path)
   eq(result, expected)
 end
 
-T['setup()']['param_str are attached preceding org'] = function()
+T["setup()"]["param_str are attached preceding org"] = function()
   local result = child.lua_get('B:new():cmd("apex"):act("run"):addParamStr("-b bb"):addParams("-c"):build()')
   local expected = 'sf apex run -c -b bb -o "t_org"'
 
   eq(result, expected)
 end
 
-T['setup()']['org name with space is safely supported'] = function()
+T["setup()"]["org name with space is safely supported"] = function()
   local result = child.lua_get('B:new():cmd("apex"):act("run"):set_org("target org"):build()')
   local expected = 'sf apex run -o "target org"'
 
   eq(result, expected)
 end
 
-T['setup()']['localOnly() by-passes the org param'] = function()
+T["setup()"]["localOnly() by-passes the org param"] = function()
   local result = child.lua_get('B:new():cmd("lightning"):act("generate component"):localOnly():build()')
-  local expected = string.format('sf lightning generate component')
+  local expected = string.format("sf lightning generate component")
 
   eq(result, expected)
 end

--- a/tests/test_config.lua
+++ b/tests/test_config.lua
@@ -1,4 +1,4 @@
-local helpers = dofile('tests/helpers.lua')
+local helpers = dofile("tests/helpers.lua")
 local child = helpers.new_child_neovim()
 local expect, eq = helpers.expect, helpers.expect.equality
 local new_set = MiniTest.new_set
@@ -14,42 +14,52 @@ local T = new_set({
   },
 })
 
-local has_cmd_pattern = function(cmd, pattern) return expect.match(child.cmd_capture(cmd), pattern) end
-local has_nmap = function(lhs) return has_cmd_pattern('nmap ' .. lhs, 'Sf') end
-
-local no_cmd_pattern = function(cmd, pattern) return expect.no_match(child.cmd_capture(cmd), pattern) end
-local no_nmap = function(lhs) return no_cmd_pattern('nmap ' .. lhs, 'Sf') end
-
-local expect_config = function(field, value) eq(child.lua_get('vim.g.sf.' .. field), value) end
-
-T['setup()'] = new_set()
-
-T['setup()']['has filetypes defined'] = function()
-  child.open_in_sf_dir('SfProject.cls')
-  eq(child.lua_get('vim.bo.filetype'), 'apex')
-
-  child.open_in_sf_dir('Account.trigger')
-  eq(child.lua_get('vim.bo.filetype'), 'apex')
-
-  child.open_in_sf_dir('abc.soql')
-  eq(child.lua_get('vim.bo.filetype'), 'soql')
-
-  child.open_in_sf_dir('query.sosl')
-  eq(child.lua_get('vim.bo.filetype'), 'sosl')
-
-  child.open_in_sf_dir('page.html')
-  eq(child.lua_get('vim.bo.filetype'), 'html')
+local has_cmd_pattern = function(cmd, pattern)
+  return expect.match(child.cmd_capture(cmd), pattern)
+end
+local has_nmap = function(lhs)
+  return has_cmd_pattern("nmap " .. lhs, "Sf")
 end
 
-T['setup()']['has default config'] = function()
-  eq(child.lua_get('type(vim.g.sf)'), 'table')
+local no_cmd_pattern = function(cmd, pattern)
+  return expect.no_match(child.cmd_capture(cmd), pattern)
+end
+local no_nmap = function(lhs)
+  return no_cmd_pattern("nmap " .. lhs, "Sf")
+end
 
-  expect_config('enable_hotkeys', false)
-  expect_config('fetch_org_list_at_nvim_start', true)
-  expect_config('hotkeys_in_filetypes', { "apex", "sosl", "soql", "javascript", "html" })
-  expect_config('types_to_retrieve', { "ApexClass", "ApexTrigger", "StaticResource", "LightningComponentBundle" })
-  expect_config('term_config', {
-    ft = 'SFTerm',
+local expect_config = function(field, value)
+  eq(child.lua_get("vim.g.sf." .. field), value)
+end
+
+T["setup()"] = new_set()
+
+T["setup()"]["has filetypes defined"] = function()
+  child.open_in_sf_dir("SfProject.cls")
+  eq(child.lua_get("vim.bo.filetype"), "apex")
+
+  child.open_in_sf_dir("Account.trigger")
+  eq(child.lua_get("vim.bo.filetype"), "apex")
+
+  child.open_in_sf_dir("abc.soql")
+  eq(child.lua_get("vim.bo.filetype"), "soql")
+
+  child.open_in_sf_dir("query.sosl")
+  eq(child.lua_get("vim.bo.filetype"), "sosl")
+
+  child.open_in_sf_dir("page.html")
+  eq(child.lua_get("vim.bo.filetype"), "html")
+end
+
+T["setup()"]["has default config"] = function()
+  eq(child.lua_get("type(vim.g.sf)"), "table")
+
+  expect_config("enable_hotkeys", false)
+  expect_config("fetch_org_list_at_nvim_start", true)
+  expect_config("hotkeys_in_filetypes", { "apex", "sosl", "soql", "javascript", "html" })
+  expect_config("types_to_retrieve", { "ApexClass", "ApexTrigger", "StaticResource", "LightningComponentBundle" })
+  expect_config("term_config", {
+    ft = "SFTerm",
     blend = 10,
     dimensions = {
       height = 0.4,
@@ -57,24 +67,24 @@ T['setup()']['has default config'] = function()
       x = 0.5,
       y = 0.9,
     },
-    border = 'single',
-    hl = 'Normal',
+    border = "single",
+    hl = "Normal",
     clear_env = false,
   })
-  expect_config('default_dir', '/force-app/main/default/')
-  expect_config('plugin_folder_name', '/sf_cache/')
-  expect_config('auto_display_code_sign', true)
-  expect_config('code_sign_highlight', {
+  expect_config("default_dir", "/force-app/main/default/")
+  expect_config("plugin_folder_name", "/sf_cache/")
+  expect_config("auto_display_code_sign", true)
+  expect_config("code_sign_highlight", {
     covered = { fg = "#b7f071" },
     uncovered = { fg = "#f07178" },
   })
 end
 
-T['setup()']['has default term config'] = function()
-  eq(child.lua_get('type(vim.g.sf.term_config)'), 'table')
+T["setup()"]["has default term config"] = function()
+  eq(child.lua_get("type(vim.g.sf.term_config)"), "table")
 
-  eq(child.lua_get('Term.get_config()'), {
-    ft = 'SFTerm',
+  eq(child.lua_get("Term.get_config()"), {
+    ft = "SFTerm",
     blend = 10,
     dimensions = {
       height = 0.4,
@@ -82,23 +92,23 @@ T['setup()']['has default term config'] = function()
       x = 0.5,
       y = 0.9,
     },
-    border = 'single',
-    hl = 'Normal',
+    border = "single",
+    hl = "Normal",
     clear_env = false,
   })
 end
 
-T['setup()']['can set custom config'] = function()
+T["setup()"]["can set custom config"] = function()
   child.sf_setup({ enable_hotkeys = true, hotkeys_in_filetypes = { "apex" } })
 
-  eq(child.lua_get('vim.g.sf.enable_hotkeys'), true)
-  eq(child.lua_get('vim.g.sf.hotkeys_in_filetypes'), { "apex" })
+  eq(child.lua_get("vim.g.sf.enable_hotkeys"), true)
+  eq(child.lua_get("vim.g.sf.hotkeys_in_filetypes"), { "apex" })
 end
 
-T['setup()']['can set custom term config'] = function()
+T["setup()"]["can set custom term config"] = function()
   local custom_cfg = {
     term_config = {
-      ft = 'MyTerm',
+      ft = "MyTerm",
       blend = 3,
       dimensions = {
         height = 0.8,
@@ -106,166 +116,164 @@ T['setup()']['can set custom term config'] = function()
         x = 0.5,
         y = 0.9,
       },
-      border = 'single',
-      hl = 'Normal',
+      border = "single",
+      hl = "Normal",
       clear_env = true,
-    }
+    },
   }
 
   child.sf_setup(custom_cfg)
 
-  eq(child.lua_get('Term.get_config()'), custom_cfg.term_config)
+  eq(child.lua_get("Term.get_config()"), custom_cfg.term_config)
 end
 
-T['setup()']['has default code sign config'] = function()
-  eq(child.lua_get('type(vim.g.sf.code_sign_highlight)'), 'table')
+T["setup()"]["has default code sign config"] = function()
+  eq(child.lua_get("type(vim.g.sf.code_sign_highlight)"), "table")
 
-  has_cmd_pattern('highlight SfCovered', child.lua_get('vim.g.sf.code_sign_highlight.covered.fg'))
-  has_cmd_pattern('highlight SfUncovered', child.lua_get('vim.g.sf.code_sign_highlight.uncovered.fg'))
+  has_cmd_pattern("highlight SfCovered", child.lua_get("vim.g.sf.code_sign_highlight.covered.fg"))
+  has_cmd_pattern("highlight SfUncovered", child.lua_get("vim.g.sf.code_sign_highlight.uncovered.fg"))
 
   eq(vim.tbl_isempty(child.fn.sign_getdefined("sf_covered")), false)
   eq(vim.tbl_isempty(child.fn.sign_getdefined("sf_uncovered")), false)
 end
 
-T['setup()']['no user-keys by default'] = function()
-  child.open_in_sf_dir('test.txt')
+T["setup()"]["no user-keys by default"] = function()
+  child.open_in_sf_dir("test.txt")
 
   -- global;
-  no_nmap('<leader>ss')
-  no_nmap('<leader>sf')
-  no_nmap('<leader>so')
-  no_nmap('<leader>ml')
+  no_nmap("<leader>ss")
+  no_nmap("<leader>sf")
+  no_nmap("<leader>so")
+  no_nmap("<leader>ml")
 
   -- file-level;
-  no_nmap('<leader>sp')
-  no_nmap('<leader>sr')
+  no_nmap("<leader>sp")
+  no_nmap("<leader>sr")
 end
 
-T['setup()']['no user-keys when non-sf-project dir'] = function()
+T["setup()"]["no user-keys when non-sf-project dir"] = function()
   child.sf_setup({ enable_hotkeys = true })
-  child.open_in_non_sf_dir('NonsfProject.cls')
+  child.open_in_non_sf_dir("NonsfProject.cls")
 
   -- global;
-  no_nmap('<leader>ss')
-  no_nmap('<leader>sf')
-  no_nmap('<leader>so')
-  no_nmap('<leader>ml')
+  no_nmap("<leader>ss")
+  no_nmap("<leader>sf")
+  no_nmap("<leader>so")
+  no_nmap("<leader>ml")
 
   -- file-level;
-  no_nmap('<leader>sp')
-  no_nmap('<leader>sr')
+  no_nmap("<leader>sp")
+  no_nmap("<leader>sr")
 end
 
-T['setup()']['only global user-keys when 1. in sf-project dir 2. opened file not in "hotkeys_in_filetypes"'] = function()
+T["setup()"]['only global user-keys when 1. in sf-project dir 2. opened file not in "hotkeys_in_filetypes"'] = function()
   child.sf_setup({ enable_hotkeys = true })
-  child.open_in_sf_dir('test.txt')
+  child.open_in_sf_dir("test.txt")
 
   -- global;
-  has_nmap('<leader>ss')
-  has_nmap('<leader>sf')
-  has_nmap('<leader>so')
-  has_nmap('<leader>ml')
+  has_nmap("<leader>ss")
+  has_nmap("<leader>sf")
+  has_nmap("<leader>so")
+  has_nmap("<leader>ml")
 
   -- file-level;
-  no_nmap('<leader>sp')
-  no_nmap('<leader>sr')
+  no_nmap("<leader>sp")
+  no_nmap("<leader>sr")
 end
 
-T['setup()']['only global user-keys when 0. enable_hotkeys 1. in sf-project sub-dir 2. opened file not in "hotkeys_in_filetypes"'] = function()
+T["setup()"]['only global user-keys when 0. enable_hotkeys 1. in sf-project sub-dir 2. opened file not in "hotkeys_in_filetypes"'] = function()
   child.sf_setup({ enable_hotkeys = true })
   child.go_to_sf_sub_dir()
 
   -- global;
-  has_nmap('<leader>ss')
-  has_nmap('<leader>sf')
-  has_nmap('<leader>so')
-  has_nmap('<leader>ml')
+  has_nmap("<leader>ss")
+  has_nmap("<leader>sf")
+  has_nmap("<leader>so")
+  has_nmap("<leader>ml")
 
   -- file-level;
-  no_nmap('<leader>sp')
-  no_nmap('<leader>sr')
+  no_nmap("<leader>sp")
+  no_nmap("<leader>sr")
 end
 
-T['setup()']['has all user-keys when 0. enable_hotkeys 1. in sf-project sub-dir 2. opened file in "hotkeys_in_filetypes"'] = function()
+T["setup()"]['has all user-keys when 0. enable_hotkeys 1. in sf-project sub-dir 2. opened file in "hotkeys_in_filetypes"'] = function()
   child.sf_setup({ enable_hotkeys = true })
-  child.open_in_sf_dir('SfProject.cls')
+  child.open_in_sf_dir("SfProject.cls")
 
   -- global;
-  has_nmap('<leader>ss')
-  has_nmap('<leader>sf')
-  has_nmap('<leader>so')
-  has_nmap('<leader>ml')
+  has_nmap("<leader>ss")
+  has_nmap("<leader>sf")
+  has_nmap("<leader>so")
+  has_nmap("<leader>ml")
 
   -- file-level;
-  has_nmap('<leader>sp')
-  has_nmap('<leader>sr')
+  has_nmap("<leader>sp")
+  has_nmap("<leader>sr")
 end
 
-T['setup()']['global user-keys disabled -> enabled when 0. enable_hotkeys 1. switching files from non-sf-project to sf-project folder'] = function()
+T["setup()"]["global user-keys disabled -> enabled when 0. enable_hotkeys 1. switching files from non-sf-project to sf-project folder"] = function()
   child.sf_setup({ enable_hotkeys = true })
-  child.open_in_non_sf_dir('test.txt')
+  child.open_in_non_sf_dir("test.txt")
 
-  no_nmap('<leader>ss')
-  no_nmap('<leader>sf')
-  no_nmap('<leader>so')
-  no_nmap('<leader>ml')
+  no_nmap("<leader>ss")
+  no_nmap("<leader>sf")
+  no_nmap("<leader>so")
+  no_nmap("<leader>ml")
 
-  child.open_in_sf_dir('SfProject.cls')
-  has_nmap('<leader>ss')
-  has_nmap('<leader>sf')
-  has_nmap('<leader>so')
-  has_nmap('<leader>ml')
-
+  child.open_in_sf_dir("SfProject.cls")
+  has_nmap("<leader>ss")
+  has_nmap("<leader>sf")
+  has_nmap("<leader>so")
+  has_nmap("<leader>ml")
 end
 
-T['setup()']['global user-keys disabled -> enabled when 0. enable_hotkeys 1. switching path from non-sf-project to sf-project folder'] = function()
+T["setup()"]["global user-keys disabled -> enabled when 0. enable_hotkeys 1. switching path from non-sf-project to sf-project folder"] = function()
   child.sf_setup({ enable_hotkeys = true })
   local root_path = child.fn.getcwd()
   child.go_to_non_sf_dir()
 
-  no_nmap('<leader>ss')
-  no_nmap('<leader>sf')
-  no_nmap('<leader>so')
-  no_nmap('<leader>ml')
+  no_nmap("<leader>ss")
+  no_nmap("<leader>sf")
+  no_nmap("<leader>so")
+  no_nmap("<leader>ml")
 
-  child.cmd('cd ' .. root_path .. '/tests/dir/sf-project/sf_cache/')
-  has_nmap('<leader>ss')
-  has_nmap('<leader>sf')
-  has_nmap('<leader>so')
-  has_nmap('<leader>ml')
-
+  child.cmd("cd " .. root_path .. "/tests/dir/sf-project/sf_cache/")
+  has_nmap("<leader>ss")
+  has_nmap("<leader>sf")
+  has_nmap("<leader>so")
+  has_nmap("<leader>ml")
 end
 
-T['setup()']['SFTerm filetype has its user-keys always defined by autocmd despite of non-sf-project dir.'] = function()
-  child.open_in_non_sf_dir('SFTerm')
-  no_nmap('<leader><leader>')
-  no_nmap('<C-c>')
+T["setup()"]["SFTerm filetype has its user-keys always defined by autocmd despite of non-sf-project dir."] = function()
+  child.open_in_non_sf_dir("SFTerm")
+  no_nmap("<leader><leader>")
+  no_nmap("<C-c>")
 
-  child.cmd('setfiletype SFTerm')
-  has_nmap('<leader><leader>')
-  has_nmap('<C-c>')
+  child.cmd("setfiletype SFTerm")
+  has_nmap("<leader><leader>")
+  has_nmap("<C-c>")
 end
 
-T['setup()']['default has a VimEnter event defined'] = function()
-  eq(#child.api.nvim_get_autocmds({ event = 'VimEnter', group = 'SF' }), 1)
+T["setup()"]["default has a VimEnter event defined"] = function()
+  eq(#child.api.nvim_get_autocmds({ event = "VimEnter", group = "SF" }), 1)
 end
 
-T['setup()']['the VimEnter event can be disabled by custom config'] = function()
+T["setup()"]["the VimEnter event can be disabled by custom config"] = function()
   child.sf_setup({ fetch_org_list_at_nvim_start = false })
 
-  eq(#child.api.nvim_get_autocmds({ event = 'VimEnter', group = 'SF' }), 0)
+  eq(#child.api.nvim_get_autocmds({ event = "VimEnter", group = "SF" }), 0)
 end
 
-T['setup()']['no user commands in non-sf-project dir'] = function()
-  child.open_in_non_sf_dir('test.txt')
+T["setup()"]["no user commands in non-sf-project dir"] = function()
+  child.open_in_non_sf_dir("test.txt")
 
-  eq(child.api.nvim_get_commands({})['SF'], nil)
+  eq(child.api.nvim_get_commands({})["SF"], nil)
 end
 
-T['setup()']['has user commands in sf-project dir'] = function()
-  child.open_in_sf_dir('text.txt')
+T["setup()"]["has user commands in sf-project dir"] = function()
+  child.open_in_sf_dir("text.txt")
 
-  eq(child.api.nvim_get_commands({})['SF'].name, 'SF')
+  eq(child.api.nvim_get_commands({})["SF"].name, "SF")
 end
 
 return T

--- a/tests/test_core.lua
+++ b/tests/test_core.lua
@@ -1,4 +1,4 @@
-local helpers = dofile('tests/helpers.lua')
+local helpers = dofile("tests/helpers.lua")
 local child = helpers.new_child_neovim()
 local expect, eq = helpers.expect, helpers.expect.equality
 local new_set = MiniTest.new_set
@@ -20,41 +20,53 @@ local T = new_set({
   },
 })
 
-local has_cmd_pattern = function(cmd, pattern) return expect.match(child.cmd_capture(cmd), pattern) end
-local has_nmap = function(lhs) return has_cmd_pattern('nmap ' .. lhs, 'Sf') end
+local has_cmd_pattern = function(cmd, pattern)
+  return expect.match(child.cmd_capture(cmd), pattern)
+end
+local has_nmap = function(lhs)
+  return has_cmd_pattern("nmap " .. lhs, "Sf")
+end
 
-local no_cmd_pattern = function(cmd, pattern) return expect.no_match(child.cmd_capture(cmd), pattern) end
-local no_nmap = function(lhs) return no_cmd_pattern('nmap ' .. lhs, 'Sf') end
+local no_cmd_pattern = function(cmd, pattern)
+  return expect.no_match(child.cmd_capture(cmd), pattern)
+end
+local no_nmap = function(lhs)
+  return no_cmd_pattern("nmap " .. lhs, "Sf")
+end
 
-local expect_config = function(field, value) eq(child.lua_get('vim.g.sf.' .. field), value) end
+local expect_config = function(field, value)
+  eq(child.lua_get("vim.g.sf." .. field), value)
+end
 
-T['get_target_org()'] = new_set()
+T["get_target_org()"] = new_set()
 
-T['get_target_org()']['return target_org'] = function()
-  local value = 'sandbox1'
+T["get_target_org()"]["return target_org"] = function()
+  local value = "sandbox1"
   local lua_cmd = string.format('Util.target_org = "%s"', value)
 
   child.lua(lua_cmd)
-  eq(child.lua('return Sf.get_target_org()'), value)
+  eq(child.lua("return Sf.get_target_org()"), value)
 end
 
-T['get_target_org()']['throws when empty target_org'] = function()
-  local lua_cmd = string.format('Sf.get_target_org()')
+T["get_target_org()"]["throws when empty target_org"] = function()
+  local lua_cmd = string.format("Sf.get_target_org()")
 
-  expect.error(function() child.lua(lua_cmd) end)
+  expect.error(function()
+    child.lua(lua_cmd)
+  end)
 end
 
-T['covered_percent()'] = new_set()
+T["covered_percent()"] = new_set()
 
-T['covered_percent()']['return covered_percent from test_sign'] = function()
+T["covered_percent()"]["return covered_percent from test_sign"] = function()
   local value = "10"
   local lua_cmd = string.format('Test_sign.covered_percent = "%s"', value)
 
   child.lua(lua_cmd)
-  eq(child.lua('return Sf.covered_percent()'), value)
+  eq(child.lua("return Sf.covered_percent()"), value)
 end
 
-T['copy_apex_name()'] = new_set()
+T["copy_apex_name()"] = new_set()
 
 -- TODO: works only locally, fail in CI
 -- T['copy_apex_name()']['return apex name'] = function()

--- a/tests/test_org.lua
+++ b/tests/test_org.lua
@@ -1,4 +1,4 @@
-local helpers = dofile('tests/helpers.lua')
+local helpers = dofile("tests/helpers.lua")
 local child = helpers.new_child_neovim()
 local expect, eq = MiniTest.expect, MiniTest.expect.equality
 local new_set = MiniTest.new_set
@@ -6,7 +6,7 @@ local new_set = MiniTest.new_set
 -- helper
 
 local mock_test = function()
-  child.cmd('luafile tests/mock/mock.lua')
+  child.cmd("luafile tests/mock/mock.lua")
 end
 
 local T = new_set({
@@ -20,10 +20,10 @@ local T = new_set({
   },
 })
 
-T['fetch_org_list'] = new_set({ hooks = { pre_case = mock_test } })
+T["fetch_org_list"] = new_set({ hooks = { pre_case = mock_test } })
 
-T['fetch_org_list']['test1'] = function()
-  eq(child.lua_get([[vim.lsp.buf_get_clients()]]), {'mock client'})
+T["fetch_org_list"]["test1"] = function()
+  eq(child.lua_get([[vim.lsp.buf_get_clients()]]), { "mock client" })
 end
 --
 -- T['get()']['target_org empty then err'] = function()


### PR DESCRIPTION
This PR creates a `.stylua.toml` file on the project root, and edits all `.lua` files in the project to conform to stylua rules. This addresses #239. Because this includes so many changes, each file is edited in its own commit, so as to make it easier to track.

I've gone through all changes, and all but _one_ are just whitespace or quotation style changes. However, there's one thing we should take a look at:

In `lua/sf/term.lua`, line 112, the second argument in `string.gsub` was changed from `"\'"` to `"'"`. I'm assuming the code here simply was escaping the single quote in the code, and not replacing with an actual escaped quote. Was escaping the quotes what was meant to be doing? In that case, I assume the second argument should be `"\\'"`?