### PR TITLE
feat: force open retrieved file

### DIFF
--- a/lua/sf/term.lua
+++ b/lua/sf/term.lua
@@ -43,9 +43,13 @@ function Term.retrieve()
   if U.is_empty_str(U.target_org) then
     return U.show_err("Target_org empty!")
   end
+  local filename = vim.fn.expandcmd("%:p")
+    local cb = function ()
+        U.try_open_file(filename)
+    end
   -- local cmd = vim.fn.expandcmd('sf project retrieve start -d "%:p" -o ') .. U.get()
-  local cmd = B:new():cmd("project"):act("retrieve start"):addParams("-d", "%:p"):build()
-  t:run(cmd)
+  local cmd = B:new():cmd("project"):act("retrieve start"):addParams("-d", filename):build()
+  t:run(cmd, cb)
 end
 
 function Term.retrieve_delta()

--- a/lua/sf/util.lua
+++ b/lua/sf/util.lua
@@ -280,7 +280,7 @@ end
 ---@param path string
 M.try_open_file = function(path)
   if M.file_readable(path) then
-    local open_new_file = string.format(":e %s", path)
+    local open_new_file = string.format(":e! %s", path)
     vim.cmd(open_new_file)
   end
 end


### PR DESCRIPTION
This PR makes it so that when a file is retrieved using `Term.retrieve()`, the retrieved file is forcibly opened (`:e!`) after retrieval (see #231)

It does so by calling `util.try_open_file` as a callback, and edits the cmd in `try_open_file` to force the edit. This method is currently called only when:
- Creating new components, where adding the `!` would make no difference
- Retrieving an Apex class using `SF md list`, in which case, if you have the Apex class opened, it makes sense to use `!`, since it works as calling retrieve on the opened file
- The new feature, which is what we want