### PR TITLE
feat: change how tables are converted to strings

### DIFF
--- a/lua/sf/util.lua
+++ b/lua/sf/util.lua
@@ -189,10 +189,13 @@ end
 ---@param tbl table
 ---@return string
 M.table_to_string_lines = function(tbl)
-  local result = ""
-  for key, value in pairs(tbl) do
-    result = result .. key .. ": " .. tostring(value) .. "\n"
-  end
+  local result = vim.inspect(tbl)
+  result = string.gsub(result, ".-\n%s+", "", 1) -- Remove the top opening brace line
+  result = string.gsub(result, "\n}", "") -- Remove the last closing brace line
+  result = string.gsub(result, "\n%s+", "\n") -- Remove indentation in table items
+  result = string.gsub(result, "%s=", ":") -- Replace = with : and remove space after key
+  result = string.gsub(result, ",\n", "\n") -- Remove end of line commas
+  result = string.gsub(result, "\"", "") -- Remove quotation marks around string values
   return result
 end
 

--- a/lua/sf/util.lua
+++ b/lua/sf/util.lua
@@ -189,13 +189,16 @@ end
 ---@param tbl table
 ---@return string
 M.table_to_string_lines = function(tbl)
-  local result = vim.inspect(tbl)
-  result = string.gsub(result, ".-\n%s+", "", 1) -- Remove the top opening brace line
-  result = string.gsub(result, "\n}", "") -- Remove the last closing brace line
-  result = string.gsub(result, "\n%s+", "\n") -- Remove indentation in table items
-  result = string.gsub(result, "%s=", ":") -- Replace = with : and remove space after key
-  result = string.gsub(result, ",\n", "\n") -- Remove end of line commas
-  result = string.gsub(result, "\"", "") -- Remove quotation marks around string values
+  local inspect_opts = {
+    newline = "",
+    indent = "",
+  }
+
+  local result = vim.inspect(tbl, inspect_opts)
+  result = string.gsub(result, "^{(.*)}$", "%1") -- Remove surrounding braces
+  result = string.gsub(result, "%s*=%s*", ": ") -- Change " = " between key and value to ": "
+  result = string.gsub(result, ",%s*", "\n") -- Add newlines after each key=val pair, and remove commas
+  result = string.gsub(result, '"', "") -- Remove quotation marks around string values
   return result
 end
 


### PR DESCRIPTION
This PR addresses #234 and how tables are converted into a string representation for fzf previews (`SF md list` and `SF org pullLog`). It uses the fact that `vim.inspect` retains the order of keys in the table, then transforms the string representation returned by `vim.inspect` into something that resembles more the original intention.

@xixiaofinland this may be a controversial solution, I can imagine, just because it's kind of a clunky workaround to work with regex, but I think the tables we're handling are consistent and well understood enough that I don't expect this to bring up issues. However, if you're not convinced by this, I get it.

This is what the result looks like in both cases:
![image](https://github.com/user-attachments/assets/6f7b998a-f572-4427-95a8-58f1d0ea9d9e)

![image](https://github.com/user-attachments/assets/f43189e9-f885-4977-9509-e14b7c8126ff)
