### PR TITLE
feat: create triggers

### DIFF
--- a/lua/sf/init.lua
+++ b/lua/sf/init.lua
@@ -133,6 +133,9 @@ Sf.create_aura_bundle = Metadata.create_aura_bundle
 --- Creates a new LWC Bundle using an input name or prompting the user to enter one
 Sf.create_lwc_bundle = Metadata.create_lwc_bundle
 
+--- Creates an apex trigger using an input name or prompting the user to enter one
+Sf.create_trigger = Metadata.create_trigger
+
 -- From Test module ==========================================================
 
 --- Open a top-split window to display the Apex tests in the current file.

--- a/lua/sf/md.lua
+++ b/lua/sf/md.lua
@@ -37,6 +37,10 @@ function Md.create_lwc_bundle()
   H.create_lwc_bundle()
 end
 
+function Md.create_trigger()
+  H.create_trigger()
+end
+
 -- helper;
 
 ---@param name string
@@ -251,6 +255,26 @@ end
 ---@param name string
 H.create_lwc_bundle = function(name)
   U.run_cb_with_input(name, "Enter LWC bundle name: ", H.generate_lwc)
+end
+
+---@param name string
+H.generate_trigger = function(name)
+  local cmd = B:new()
+    :cmd("apex")
+    :act("generate")
+    :subact("trigger")
+    :addParams({ ["-d"] = U.get_default_dir_path() .. "triggers", ["-n"] = name })
+    :localOnly()
+    :buildAsTable()
+
+  U.silent_system_call(cmd, nil, "Something went wrong creating the trigger", function()
+    U.try_open_file(U.get_default_dir_path() .. "triggers/" .. name .. ".trigger")
+  end)
+end
+
+---@param name string
+H.create_trigger = function(name)
+  U.run_cb_with_input(name, "Enter Trigger name: ", H.generate_trigger)
 end
 
 return Md

--- a/lua/sf/sub/config_user_command.lua
+++ b/lua/sf/sub/config_user_command.lua
@@ -101,6 +101,7 @@ M.sub_cmd_tbl = {
       aura = Sf.create_aura_bundle,
       ctags = Sf.create_ctags,
       ctagsAndList = Sf.create_and_list_ctags,
+      trigger = Sf.create_trigger,
     },
     impl = common_impl,
     complete = function(subcmd_arg_lead)

--- a/lua/sf/util.lua
+++ b/lua/sf/util.lua
@@ -162,6 +162,40 @@ M.job_call = function(cmd, msg, err_msg, cb)
   M.silent_job_call(cmd, msg, err_msg, cb)
 end
 
+---@param cmd table
+---@param msg string|nil
+---@param err_msg string|nil
+---@param cb function|nil
+M.silent_system_call = function(cmd, msg, err_msg, cb)
+  local system_callback = function(obj)
+    if obj.code ~= 0 then
+      if err_msg ~= nil then
+        M.show_err(err_msg)
+      end
+      return
+    end
+
+    if msg ~= nil then
+      M.show(msg)
+    end
+
+    if cb ~= nil then
+      cb(obj)
+    end
+  end
+
+  vim.system(cmd, {}, vim.schedule_wrap(system_callback))
+end
+
+---@param cmd table
+---@param msg string|nil
+---@param err_msg string|nil
+---@param cb function|nil
+M.system_call = function(cmd, msg, err_msg, cb)
+  M.show("| Async job starts...")
+  M.silent_system_call(cmd, msg, err_msg, cb)
+end
+
 -- Copy current file name without dot-after, e.g. copy "Hello" from "Hello.cls"
 M.copy_apex_name = function()
   local file_name = vim.split(vim.fn.expand("%:t"), ".", { trimempty = true, plain = true })[1]


### PR DESCRIPTION
This PR adds a method to create apex triggers, imitating the ones we have for classes, aura and lwc. It uses the new `buildAsTable` method to create it using `vim.system` instead of `vim.fn.jobstart`. It also creates `util` methods for calling `vim.system` the same way we can now generically call `vim.fn.jobstart`, so we can start using those to move methods from the old vimscript to the new method. (Once this merges, I'll move `pull_log` to use these new util methods, but didn't want to pile into a single PR)

Finally, it adds the new command to `init` and creates a user command for it