### PR TITLE
fix: dont fail validate cmd for local only

### DIFF
--- a/lua/sf/sub/cmd_builder.lua
+++ b/lua/sf/sub/cmd_builder.lua
@@ -98,8 +98,11 @@ function CommandBuilder:validate()
   local required_fields = {
     { field = "command", message = '"command" property not set' },
     { field = "action", message = '"action" property not set' },
-    { field = "org", message = "no given org value nor default target_org" },
   }
+
+  if self.require_org then
+    table.insert(required_fields, { field = "org", message = "no given org value nor default target_org" })
+  end
 
   for _, field in ipairs(required_fields) do
     if U.is_empty_str(self[field.field]) then


### PR DESCRIPTION
Just noticed this while working on the create trigger PR. The `validate` command in `cmd_builder` fails if an org is not there, even if the command is `localOnly`. In this case it should not fail if the org is missing. This PR fixes that.