### PR TITLE
feat: make test signs enabled by default

### DIFF
--- a/lua/sf/config.lua
+++ b/lua/sf/config.lua
@@ -60,6 +60,7 @@ local default_cfg = {
 
   -- after the test running with code coverage completes, display uncovered line sign automatically.
   -- you can set it to `false`, then manually run toggle_sign command.
+  -- this also makes existing coverage signs enabled by default on nvim startup
   auto_display_code_sign = true,
 
   -- code coverage sign icon colors

--- a/lua/sf/sub/test_sign.lua
+++ b/lua/sf/sub/test_sign.lua
@@ -29,7 +29,8 @@ M.setup = function()
   vim.fn.sign_define(covered_sign, { text = "▎", texthl = covered_group })
   vim.fn.sign_define(uncovered_sign, { text = "▎", texthl = uncovered_group })
 
-  enabled = vim.g.sf.auto_display_code_sign or false
+  local in_project, _ = pcall(U.get_sf_root)
+  enabled = in_project and (vim.g.sf.auto_display_code_sign or false)
 end
 
 M.toggle = function()

--- a/lua/sf/sub/test_sign.lua
+++ b/lua/sf/sub/test_sign.lua
@@ -28,6 +28,8 @@ M.setup = function()
 
   vim.fn.sign_define(covered_sign, { text = "▎", texthl = covered_group })
   vim.fn.sign_define(uncovered_sign, { text = "▎", texthl = uncovered_group })
+
+  enabled = vim.g.sf.auto_display_code_sign or false
 end
 
 M.toggle = function()

--- a/lua/sf/sub/test_sign.lua
+++ b/lua/sf/sub/test_sign.lua
@@ -139,12 +139,14 @@ H.get_coverage = function()
 
   local tbl = U.read_file_in_plugin_folder("test_result.json")
   if not tbl then
-    return vim.notify_once("Local test_result.json not found.", vim.log.levels.WARN)
+    vim.notify_once("Local test_result.json not found.", vim.log.levels.WARN)
+    return nil
   end
 
   coverage = vim.tbl_get(tbl, "result", "coverage", "coverage")
   if coverage == nil then
-    return vim.notify_once("Local test_result.json has no coverage element.", vim.log.levels.WARN)
+    vim.notify_once("Local test_result.json has no coverage element.", vim.log.levels.WARN)
+    return nil
   end
 
   cache = coverage


### PR DESCRIPTION
This tackles #247 by making it so that if a user has `auto_display_code_sign` as `true` in setup, code coverage signs are enabled by default on nvim startup.