### PR TITLE
chore: make pull_log use util system_call methods

### DIFF
--- a/lua/sf/util.lua
+++ b/lua/sf/util.lua
@@ -191,8 +191,8 @@ end
 ---@param msg string|nil
 ---@param err_msg string|nil
 ---@param cb function|nil
-M.system_call = function(cmd, msg, err_msg, cb)
-  M.show("| Async job starts...")
+M.system_call = function(cmd, msg, err_msg, cb, pre_msg)
+  M.show(pre_msg or "| Async job starts...")
   M.silent_system_call(cmd, msg, err_msg, cb)
 end
 


### PR DESCRIPTION
This makes it so that the `pull_log` method uses the new `util` generic methods for calling `vim.system`. It also adds the capability to customize the message shown when an async job is called using `util.system_call`