### PR TITLE
feat: make sf wait time configurable

### DIFF
--- a/lua/sf/config.lua
+++ b/lua/sf/config.lua
@@ -68,6 +68,10 @@ local default_cfg = {
     covered = { fg = "#b7f071" }, -- set `fg = ""` to disable this sign icon
     uncovered = { fg = "#f07178" }, -- set `fg = ""` to disable this sign icon
   },
+
+  -- wait time for sf commands (in minutes)
+  -- running all local tests still defaults to 180 mins, as it is a costly operation
+  sf_wait_time = 5,
 }
 
 local apply_config = function(opt)

--- a/lua/sf/term.lua
+++ b/lua/sf/term.lua
@@ -101,7 +101,7 @@ function Term.run_query()
     return U.show_err("Target_org empty!")
   end
   -- local cmd = vim.fn.expandcmd('sf data query -w 5 -f "%:p" -o ') .. U.get()
-  local cmd = B:new():cmd("data"):act("query"):addParams("-w", 5):addParams("-f", "%:p"):build()
+  local cmd = B:new():cmd("data"):act("query"):addParams("-w", vim.g.sf.sf_wait_time):addParams("-f", "%:p"):build()
   t:run(cmd)
 end
 
@@ -110,7 +110,8 @@ function Term.run_tooling_query()
     return U.show_err("Target_org empty!")
   end
   -- local cmd = vim.fn.expandcmd('sf data query -t -w 5 -f "%:p" -o ') .. U.get()
-  local cmd = B:new():cmd("data"):act("query"):addParams({ ["-w"] = 5, ["-f"] = "%:p", ["-t"] = "" }):build()
+  local cmd =
+    B:new():cmd("data"):act("query"):addParams({ ["-w"] = vim.g.sf.sf_wait_time, ["-f"] = "%:p", ["-t"] = "" }):build()
   t:run(cmd)
 end
 

--- a/lua/sf/test.lua
+++ b/lua/sf/test.lua
@@ -40,7 +40,7 @@ Test.run_current_test_with_coverage = function()
     :addParams({
       ["-t"] = test_class_name .. "." .. test_name,
       ["-r"] = "human",
-      ["-w"] = "5",
+      ["-w"] = vim.g.sf.sf_wait_time,
       ["-c"] = "",
     })
     :build()
@@ -69,7 +69,7 @@ Test.run_current_test = function()
     :addParams({
       ["-t"] = test_class_name .. "." .. test_name,
       ["-r"] = "human",
-      ["-w"] = "5",
+      ["-w"] = vim.g.sf.sf_wait_time,
     })
     :build()
 
@@ -89,7 +89,7 @@ Test.run_all_tests_in_this_file_with_coverage = function()
     :addParams({
       ["-n"] = test_class_name,
       ["-r"] = "human",
-      ["-w"] = "5",
+      ["-w"] = vim.g.sf.sf_wait_time,
       ["-c"] = "",
     })
     :build()
@@ -113,7 +113,7 @@ Test.run_all_tests_in_this_file = function(cb)
     :addParams({
       ["-n"] = test_class_name,
       ["-r"] = "human",
-      ["-w"] = "5",
+      ["-w"] = vim.g.sf.sf_wait_time,
     })
     :build()
 
@@ -281,7 +281,7 @@ P.set_keys = function()
       return U.show_err("No test is selected.")
     end
 
-    local cmd = create_cmd({ ["-w"] = "5", ["-r"] = "human" })
+    local cmd = create_cmd({ ["-w"] = vim.g.sf.sf_wait_time, ["-r"] = "human" })
 
     P.close()
     T.run(cmd)
@@ -294,7 +294,7 @@ P.set_keys = function()
       return U.show_err("No test is selected.")
     end
 
-    local cmd = create_cmd({ ["-w"] = "5", ["-r"] = "human", ["-c"] = "" })
+    local cmd = create_cmd({ ["-w"] = vim.g.sf.sf_wait_time, ["-r"] = "human", ["-c"] = "" })
 
     P.close()
     T.run(cmd, H.save_test_coverage_locally)


### PR DESCRIPTION
This makes the default value for the `-w` flag in sf commands configurable from the plugin config, while still defaulting to 5 as it is right now.

The `-w` flag for running all tests in org does not use the config and still defaults to 180 mins, as this is understood to be a costly operation that can take a long time.