### PR TITLE
feat: allow for some params to not be expanded

### DIFF
--- a/lua/sf/md.lua
+++ b/lua/sf/md.lua
@@ -66,7 +66,7 @@ H.retrieve_md = function(type, name, cb)
   U.get_sf_root()
 
   local type_name = string.format("%s:%s", type, name)
-  local cmd = B:new():cmd("project"):act("retrieve start"):addParams("-m", type_name, false):build()
+  local cmd = B:new():cmd("project"):act("retrieve start"):addParamsNoExpand("-m", type_name):build()
   T.run(cmd, cb)
 end
 

--- a/lua/sf/md.lua
+++ b/lua/sf/md.lua
@@ -66,7 +66,7 @@ H.retrieve_md = function(type, name, cb)
   U.get_sf_root()
 
   local type_name = string.format("%s:%s", type, name)
-  local cmd = B:new():cmd("project"):act("retrieve start"):addParams("-m", type_name):build()
+  local cmd = B:new():cmd("project"):act("retrieve start"):addParams("-m", type_name, false):build()
   T.run(cmd, cb)
 end
 

--- a/lua/sf/sub/cmd_builder.lua
+++ b/lua/sf/sub/cmd_builder.lua
@@ -65,18 +65,32 @@ end
 function CommandBuilder:addParams(...)
   local args = { ... }
   if type(args[1]) == "table" then
-    -- If a table is passed, assume it's a list of flag-value pairs. If the value is also a table, it can contain its own value key, and an expand key indicating if the value should be expanded
+    -- If a table is passed, assume it's a list of flag-value pairs
     for flag, value in pairs(args[1]) do
-      if type(value) == "table" then
-        self.params[flag] = { value = value.value, expand = value.expand }
-      else
-        self.params[flag] = { value = value }
-      end
+      self.params[flag] = { value = value, expand = true }
     end
   else
-    -- If individual arguments are passed, assume it's a single flag-value pair, and optionally a third argument to indicate whether the param value should be expanded
-    local flag, value, expand = args[1], args[2] or "", (args[3] == nil and true) or args[3]
-    self.params[flag] = { value = value, expand = expand }
+    -- If individual arguments are passed, assume it's a single flag-value pair
+    local flag, value = args[1], args[2] or ""
+    self.params[flag] = { value = value, expand = true }
+  end
+  return self
+end
+
+---Add one or more parameters, but don't expand the values
+---@param ... string|table Either a flag and value as separate arguments, or a table of flag-value pairs
+---@return CommandBuilder
+function CommandBuilder:addParamsNoExpand(...)
+  local args = { ... }
+  if type(args[1]) == "table" then
+    -- If a table is passed, assume it's a list of flag-value pairs
+    for flag, value in pairs(args[1]) do
+      self.params[flag] = { value = value, expand = false }
+    end
+  else
+    -- If individual arguments are passed, assume it's a single flag-value pair
+    local flag, value = args[1], args[2] or ""
+    self.params[flag] = { value = value, expand = false }
   end
   return self
 end

--- a/tests/test_cmd_builder.lua
+++ b/tests/test_cmd_builder.lua
@@ -72,6 +72,37 @@ T["setup()"]["can supply mutliple params in table in addParams()"] = function()
   eq(result, expected)
 end
 
+T["setup()"]["can supply flag:value string in addParamsNoExpand(), and will not be expanded"] = function()
+  child.open_in_sf_dir("test.txt")
+  local result = child.lua_get('B:new():cmd("apex"):act("run"):addParamsNoExpand("-f", "%:p"):build()')
+  local expected = 'sf apex run -f "%:p" -o "t_org"'
+  eq(result, expected)
+end
+
+T["setup()"]["can supply flag:value string in more than one addParamsNoExpand, and none will be expanded()"] = function()
+  child.open_in_sf_dir("test.txt")
+  local result = child.lua_get(
+    'B:new():cmd("apex"):act("run"):addParamsNoExpand("-f", "%:p"):addParamsNoExpand("-c", "%:p"):build()'
+  )
+  local expected = 'sf apex run -c "%:p" -f "%:p" -o "t_org"'
+  eq(result, expected)
+end
+
+T["setup()"]["can supply table {flag = value} in addParamsNoExpand() and will not be expanded"] = function()
+  child.open_in_sf_dir("test.txt")
+  local result = child.lua_get('B:new():cmd("apex"):act("run"):addParamsNoExpand({["-f"] = "%:p"}):build()')
+  local expected = 'sf apex run -f "%:p" -o "t_org"'
+  eq(result, expected)
+end
+
+T["setup()"]["can supply multiple params in table in addParamsNoExpand() and none will be expanded"] = function()
+  child.open_in_sf_dir("test.txt")
+  local result =
+    child.lua_get('B:new():cmd("apex"):act("run"):addParamsNoExpand({["-c"] = "%:p", ["-f"] = "%:p"}):build()')
+  local expected = 'sf apex run -c "%:p" -f "%:p" -o "t_org"'
+  eq(result, expected)
+end
+
 T["setup()"]["can sort params with value alphabetically"] = function()
   local result = child.lua_get(
     'B:new():cmd("apex"):act("run"):addParams({["-f"] = "/path/", ["-c"] = "test", ["-t"] = "" }):build()'


### PR DESCRIPTION
This allows some extra verbosity at the moment of using `addParams` to `cmd_builder` to be used so that particular parameter value will **not** be expanded when the cmd is built. It's done so as to keep all the other method calls the same and working as intended.