### PR TITLE
feat: add md type to table key

### DIFF
--- a/lua/sf/md.lua
+++ b/lua/sf/md.lua
@@ -90,8 +90,9 @@ H.list_md_to_retrieve = function()
     if md_tbl ~= nil then
       for _, v in ipairs(md_tbl) do
         if v["manageableState"] == "unmanaged" then
-          md[v["fullName"]] = v
-          table.insert(md_names, v["fullName"])
+          local md_key = v["type"] .. ": " .. v["fullName"]
+          md[md_key] = v
+          table.insert(md_names, md_key)
         end
       end
     end


### PR DESCRIPTION
This addresses the issue of dupes in the `SF md list` command when more than one metadata component has the same API name across different md types.