### PR TITLE
fix: pulling was adding type to name

### DIFF
--- a/lua/sf/md.lua
+++ b/lua/sf/md.lua
@@ -101,8 +101,8 @@ H.list_md_to_retrieve = function()
   require("fzf-lua").fzf_exec(md_names, {
     actions = {
       ["default"] = function(selected)
-        H.retrieve_md(md[selected[1]]["type"], selected[1], function()
-          H.open_apex(selected[1])
+        H.retrieve_md(md[selected[1]]["type"], md[selected[1]]["fullName"], function()
+          H.open_apex(md[selected[1]]["fullName"])
         end)
       end,
     },


### PR DESCRIPTION
Sorry about this, adding the type to the fzf-lua list unwittingly added a bug, since I forgot we were using the fzf-lua list text as the fullName when pulling. This fixes that, by actively choosing the fullName property from the table instead of using the list text.

![image](https://github.com/user-attachments/assets/2167f1c7-2e25-4096-879f-f8fc3b54fd11)
