### PR TITLE
Fix Windows OS plugin file path retrieval

### DIFF
--- a/lua/sf/health.lua
+++ b/lua/sf/health.lua
@@ -7,6 +7,7 @@ M.check = function()
   H.check_tree_sitter()
   H.check_fzf_lua()
   H.check_ctag()
+  H.check_windows_os()
 end
 
 -- helper;
@@ -69,6 +70,14 @@ H.check_ctag = function()
   end
 
   vim.health.ok("ctags command found.")
+end
+
+H.check_windows_os = function()
+  if vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1 then
+    return vim.health.warn(
+      "Windows OS detected. Functionality not guaranteed."
+    )
+  end
 end
 
 return M

--- a/lua/sf/util.lua
+++ b/lua/sf/util.lua
@@ -52,7 +52,10 @@ end
 M.get_plugin_folder_path = function()
   local folder_path = M.get_sf_root() .. vim.g.sf.plugin_folder_name
   folder_path = folder_path:gsub("//", "/")
-  if folder_path:sub(1, 1) ~= "/" and folder_path:sub(1, 1) ~= "." then
+  if M.is_windows_os() then
+    folder_path = folder_path:gsub("\\", "/")
+  end
+  if folder_path:sub(1, 1) ~= "/" and folder_path:sub(1, 1) ~= "." and not M.is_windows_os() then
     folder_path = "/" .. folder_path
   end
   if folder_path:sub(-1) ~= "/" then
@@ -351,6 +354,13 @@ M.gen_doc = function()
   require("mini.doc").generate({
     "lua/sf/init.lua",
   })
+end
+
+M.is_windows_os = function()
+  if vim.fn.has("win32") or vim.fn.has("win64") then
+    return true
+  end
+  return false
 end
 
 return M


### PR DESCRIPTION
Fix #266 

- Checks Windows OS when retrieving plugin folder.
- Adds a warning in health check when Windows is detected.