### PR TITLE
fix: Windows root path and cmd with echo

### DIFF
--- a/lua/sf/sub/raw_term.lua
+++ b/lua/sf/sub/raw_term.lua
@@ -59,7 +59,15 @@ function T:run_after_setup(cmd, cb)
   api.nvim_set_current_win(self.win)
 
   local echo_msg = string.gsub(cmd, '"', '\\"')
-  local cmd_with_echo = string.format('echo -e "\\e[0;35m %s \\e[0m";%s', echo_msg, cmd) -- echo Cyan color
+  local cmd_with_echo = ''
+
+  if H.is_windows_os() then
+    local c27 = string.char(27)
+    cmd_with_echo = string.format('echo %s && %s', c27 .. '[0;35m' .. echo_msg .. c27 .. '[0m', cmd)
+  else
+    cmd_with_echo = string.format('echo -e "\\e[0;35m %s \\e[0m";%s', echo_msg, cmd) -- echo Cyan color
+  end
+  -- local cmd_with_echo = string.format('echo -e "\\e[0;35m %s \\e[0m";%s', echo_msg, cmd) -- echo Cyan color
   vim.fn.termopen(cmd_with_echo, {
     clear_env = self.config.clear_env,
     env = self.config.env,
@@ -211,6 +219,13 @@ function H.get_dimension(opts)
     col = col,
     row = row,
   }
+end
+
+function H.is_windows_os()
+  if vim.fn.has("win32") then
+    return true
+  end
+  return false
 end
 
 return T

--- a/lua/sf/util.lua
+++ b/lua/sf/util.lua
@@ -36,7 +36,10 @@ end
 M.get_default_dir_path = function()
   local dir_path = M.get_sf_root() .. vim.g.sf.default_dir
   dir_path = dir_path:gsub("//", "/")
-  if dir_path:sub(1, 1) ~= "/" and dir_path:sub(1, 1) ~= "." then
+  if M.is_windows_os() then
+    dir_path = dir_path:gsub("\\", "/")
+  end
+  if dir_path:sub(1, 1) ~= "/" and dir_path:sub(1, 1) ~= "." and not M.is_windows_os() then
     dir_path = "/" .. dir_path
   end
   if dir_path:sub(-1) ~= "/" then


### PR DESCRIPTION
Jumped the gun yesterday with PR that addressed the plugin folder. These changes will actually allow Sf.nvim to function in Windows..

- Windows terminal can't format colors the way you've integrated for the echo, so I added a windows version that does the same.

- For get_default_dir_path, changes are identical to those used on the plugin path getter from my last PR.