### PR TITLE
fix: windows check always returns true (breaking)

### DIFF
--- a/lua/sf/sub/raw_term.lua
+++ b/lua/sf/sub/raw_term.lua
@@ -59,11 +59,11 @@ function T:run_after_setup(cmd, cb)
   api.nvim_set_current_win(self.win)
 
   local echo_msg = string.gsub(cmd, '"', '\\"')
-  local cmd_with_echo = ''
+  local cmd_with_echo = ""
 
   if H.is_windows_os() then
     local c27 = string.char(27)
-    cmd_with_echo = string.format('echo %s && %s', c27 .. '[0;35m' .. echo_msg .. c27 .. '[0m', cmd)
+    cmd_with_echo = string.format("echo %s && %s", c27 .. "[0;35m" .. echo_msg .. c27 .. "[0m", cmd)
   else
     cmd_with_echo = string.format('echo -e "\\e[0;35m %s \\e[0m";%s', echo_msg, cmd) -- echo Cyan color
   end
@@ -222,7 +222,7 @@ function H.get_dimension(opts)
 end
 
 function H.is_windows_os()
-  if vim.fn.has("win32") then
+  if vim.fn.has("win32") == 1 then
     return true
   end
   return false

--- a/lua/sf/util.lua
+++ b/lua/sf/util.lua
@@ -360,7 +360,7 @@ M.gen_doc = function()
 end
 
 M.is_windows_os = function()
-  if vim.fn.has("win32") or vim.fn.has("win64") then
+  if vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1 then
     return true
   end
   return false


### PR DESCRIPTION
The current windows check is broken, as it always returns true. This causes issues in shells like zsh (at least). This is because conditionals in lua check *everything* except for `false` and `nil` as true, as explained in: https://www.lua.org/pil/2.2.html

This fixes these checks.

@xixiaofinland as an aside, this also runs stylua on these files. Maybe we should have a check to enforce changes to stick to stylua