### PR TITLE
feat: don't ignore metadata that doesn't have unmanaged

### DIFF
--- a/lua/sf/md.lua
+++ b/lua/sf/md.lua
@@ -89,7 +89,7 @@ H.list_md_to_retrieve = function()
 
     if md_tbl ~= nil then
       for _, v in ipairs(md_tbl) do
-        if v["manageableState"] == "unmanaged" then
+        if v["manageableState"] ~= "installed" then
           local md_key = v["type"] .. ": " .. v["fullName"]
           md[md_key] = v
           table.insert(md_names, md_key)


### PR DESCRIPTION
This PR makes it so that `SF md list` shows some metadata types which don't have the "unmanaged" value, even though you can retrieve them and so. I'm guessing the original intent of this was to prevent managed package classes to appear, so I've changed it to check for a value other than "installed", which is what those classes have. 

e.g.: ExperienceBundle metadata:
![image](https://github.com/user-attachments/assets/4212f1c4-1394-42f6-b57c-80f1ae147d1e)
