### PR TITLE
fix: wrap target org in quotes for aliases with spaces

### DIFF
--- a/lua/sf/org.lua
+++ b/lua/sf/org.lua
@@ -131,7 +131,7 @@ H.set_target_org = function()
   }, function(choice)
     if choice ~= nil then
       local org = string.gsub(choice, "%[S%] ", "")
-      local cmd = "sf config set target-org " .. org
+      local cmd = "sf config set target-org \"" .. org .. "\""
       local err_msg = org .. " - set target_org failed! Not in a sfdx project folder?"
       local cb = function()
         U.target_org = org


### PR DESCRIPTION
Set default org was always failing for any org aliases that have spaces. Just needed to wrap the org alias in quotes.