### PR TITLE
fix: missing plugin parent dir causes unrecoverable failure

### DIFF
--- a/lua/sf/util.lua
+++ b/lua/sf/util.lua
@@ -70,9 +70,10 @@ end
 M.create_plugin_folder_if_not_exist = function()
   local cache_folder = M.get_plugin_folder_path()
   if vim.fn.isdirectory(cache_folder) == 0 then
-    local result = vim.fn.mkdir(cache_folder)
-    if result == 0 then
-      return vim.notify("cache folder creation failed!", vim.log.levels.ERROR)
+    local ok, result = pcall(vim.fn.mkdir, cache_folder, "-p")
+    if not ok then
+      M.show_err("cache folder creation failed!")
+      M.show_err("error: " .. result)
     end
   end
 end


### PR DESCRIPTION
If the plugin folder defined in the config contains parents that don't exists (e.g.: my plugin folder is `./.sf/sf_cache`, and a brand new project doesn't create the `.sf` folder), creating the plugin folder fails. The error message was not shown, and in my case, it even prevented the lsps from loading (I'm guessing it must be something to do with the `BufEnter` autocmd).

This PR makes it so:
- The call to `mkdir` also creates parent directories if needed (no reason not to)
- The call to create the dir is protected, and the error is shown if it fails, but doesn't cause complete failure