### PR TITLE
fix: improve fetch org list performance

### DIFF
--- a/lua/sf/org.lua
+++ b/lua/sf/org.lua
@@ -191,7 +191,7 @@ H.store_orgs = function(data)
 end
 
 H.fetch_and_store_orgs = function()
-  vim.fn.jobstart("sf org list --json", {
+  vim.fn.jobstart("sf org list --json --skip-connection-status", {
     stdout_buffered = true,
     on_stdout = function(_, data)
       H.store_orgs(data)


### PR DESCRIPTION
When running the "sf org list" command, the sf cli checks each org's authentication status by sending a request to each org. This can cause the command to be very slow if you have one org that is slow to respond.

Personally, I have an org that takes over 30 seconds to respond, so launching nvim with the fetch_org_list_at_nvim_start option takes over 30 seconds for my default org to be set.

There's a --skip-connection-status flag that can be set on the "sf org list" command that skips this status check and makes the command run much more quickly. Also, we're not using the "connectedStatus" property, as far as I can tell.