### PR TITLE
fix: fix quotes and expand issue on highlight soql

### DIFF
--- a/lua/sf/term.lua
+++ b/lua/sf/term.lua
@@ -130,9 +130,8 @@ function Term.run_highlighted_soql()
   end
 
   -- local raw_cmd = string.format('sf data query -q "%s" -o %s', selected_text, U.get())
-  local raw_cmd = B:new():cmd("data"):act("query"):addParams("-q", selected_text):build()
-  local cmd = string.gsub(raw_cmd, "'", "\\'")
-  t:run(cmd)
+  local raw_cmd = B:new():cmd("data"):act("query"):addParamsNoExpand("-q", selected_text):build()
+  t:run(raw_cmd)
 end
 
 function Term.cancel()


### PR DESCRIPTION
This fixes both issues that came up on #277 : 

- It removes the line escaping the single quotes, as it doesn't look like it's needed: the command wraps the entire query in double quotes, and this makes the single quotes safe
- It changes the `addParams` method for `addParamsNoExpand`, so any `%` in `LIKE` queries is not expanded.