### PR TITLE
Overseer.nvim integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ In addition to the features, user commands and default hotkeys are also supplied
 - 🔍 (Optional) fzf-lua plugin for executing `:SF md list` and `SFListMdTypeToRetrieve` (Why not
   telescope.nvim? Because its UI is slow)
 - 🔍 (Optional) [universal ctags](https://github.com/universal-ctags/ctags) is used to enhance [Apex jump](#-enhanced-jump-to-definition-apex)
+- 🔍 (Optional) [overseer.nvim](https://github/com/stevearc/overseer) if you'd like to use the overseer integration
+
 
 ![Image 019](https://github.com/user-attachments/assets/aad0ac11-f980-423b-8332-a2b4359fb4ae)
 
@@ -134,6 +136,11 @@ require('sf').setup({
     "LightningComponentBundle"
   },
 
+  -- The terminal strategy to use for running tasks.
+  -- "integrated" - use the integrated terminal.
+  -- "overseer" - use overseer.nvim to run terminal tasks. (requires overseer.nvim as a dependency).
+  terminal = "integrated",
+  
   -- Configuration for the integrated terminal
   term_config = {
     blend = 10,     -- background transparency: 0 is fully opaque; 100 is fully transparent
@@ -364,7 +371,9 @@ You can
 
 <br>
 
-## 🖥️ Integrated terminal
+## 🖥️ Terminal
+
+### Integrated terminal
 
 ![Image 022](https://github.com/user-attachments/assets/bd61e9fc-fa0d-4782-8f2d-68e90dcb0d10)
 
@@ -378,6 +387,31 @@ The integrated terminal is designed to
 
 You can pass any shell command into `run()` method to execute it in the integrated
 terminal. For instance, `require('sf').run('ls -la')`.
+
+### Overseer.nvim 
+
+As an alternative to the integrated terminal, [overseer.nvim](https://github.com/stevearc/overseer.nvim) can be used to execute terminal commands. 
+
+Once enabled
+
+- commands executed by Sf.nvim will be created in overseer as tasks
+- the overseer task list can be show or hidden via `:OverseerToggle` 
+
+To enable, ensure overseer.nvim is a dependency and set the appropriate flag in your configuration:
+
+```
+return {
+    'xixiaofinland/sf.nvim',
+    dependencies = {
+        'nvim-treesitter/nvim-treesitter',
+        'stevearc/overseer.nvim',   
+        "ibhagwan/fzf-lua",
+    },
+    config = function()
+        require('sf').setup({ terminal = 'overseer' })
+    end
+}
+```
 
 <br>
 

--- a/lua/sf/config.lua
+++ b/lua/sf/config.lua
@@ -52,6 +52,11 @@ local default_cfg = {
     clear_env = false,
   },
 
+  -- The terminal strategy to use for running tasks.
+  -- "integrated" - use the integrated terminal.
+  -- "overseer" - use overseer.nvim to run terminal tasks. requires overseer.nvim as a dependency.
+  terminal = "integrated",
+
   -- the sf project metadata folder, update this in case you diverged from the default sf folder structure
   default_dir = "/force-app/main/default/",
 
@@ -95,8 +100,18 @@ local init = function()
 
   AutoCmd.set_auto_cmd_and_try_set_default_keys()
 
-  -- Initiate the raw term
-  require("sf.term").setup(vim.g.sf.term_config)
+  -- Initiate the term
+  local term_type = vim.g.sf.terminal or "integrated"
+  if term_type == "overseer" and not pcall(require, "overseer") then
+    -- overseer not found, fall back to integrated terminal
+    term_type = "integrated"
+  end
+
+  if term_type == "overseer" then
+    require("sf.term").overseer_setup(vim.g.sf.overseer)
+  else
+    require("sf.term").integrated_setup(vim.g.sf.term_config)
+  end
 
   require("sf.test").setup_sign()
 end

--- a/lua/sf/health.lua
+++ b/lua/sf/health.lua
@@ -7,6 +7,7 @@ M.check = function()
   H.check_tree_sitter()
   H.check_fzf_lua()
   H.check_ctag()
+  H.check_overseer()
   H.check_windows_os()
 end
 
@@ -72,11 +73,16 @@ H.check_ctag = function()
   vim.health.ok("ctags command found.")
 end
 
+H.check_overseer = function()
+  if not pcall(require, "overseer") then
+    return vim.health.warn("Optional: overseer not found. ")
+  end
+  vim.health.ok("overseer plugin found.")
+end
+
 H.check_windows_os = function()
   if vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1 then
-    return vim.health.warn(
-      "Windows OS detected. Functionality not guaranteed."
-    )
+    return vim.health.warn("Windows OS detected. Functionality not guaranteed.")
   end
 end
 

--- a/lua/sf/sub/overseer_term.lua
+++ b/lua/sf/sub/overseer_term.lua
@@ -1,0 +1,75 @@
+local api = vim.api
+local cmd = api.nvim_command
+
+local success, overseer = pcall(require, "overseer")
+
+local T = {}
+
+function T:new(cfg)
+  local config = cfg
+
+  return setmetatable({
+    config = config,
+  }, { __index = self })
+end
+
+function T:setup(cfg)
+  -- currently don't have any overseer specific config.
+  return self
+end
+
+function T:run(cmd, cb)
+  local task = overseer.new_task({
+    cmd = cmd,
+    components = { "default" },
+    metadata = {
+      source = "sf.nvim", -- set source so we can cancel tasks later if required
+    },
+  })
+
+  local handle_callback = function(t)
+    if cb ~= nil then
+      cb(self, cmd, t.exit_code)
+    end
+  end
+
+  task:subscribe("on_complete", handle_callback)
+  task:start()
+
+  return self
+end
+
+function T:cancel()
+  -- stop all task created by this plugin
+  local tasks = overseer.list_tasks()
+
+  for i, t in ipairs(tasks) do
+    if t.metadata.source == "sf.nvim" then
+      t:stop()
+    end
+  end
+end
+
+function T:toggle()
+  overseer.toggle()
+
+  return self
+end
+
+function T:open()
+  overseer.open()
+
+  return self
+end
+
+function T:close()
+  overseer.close()
+
+  return self
+end
+
+function T:get_config()
+  return self.config
+end
+
+return T

--- a/lua/sf/sub/raw_term.lua
+++ b/lua/sf/sub/raw_term.lua
@@ -107,7 +107,7 @@ function T:open()
   end
 
   if not H.is_buf_valid(self.buf) then
-    return vim.notify_once("Sf: no previous task. Run a termnimal command to initiate the term.", vim.log.levels.WARN)
+    return vim.notify_once("Sf: no previous task. Run a terminal command to initiate the term.", vim.log.levels.WARN)
   end
 
   local win = self:create_and_open_win(self.buf)
@@ -129,6 +129,11 @@ function T:close()
   api.nvim_win_close(self.win, false)
 
   return self
+end
+
+function T:cancel()
+  self.is_running = false -- set the flag to stop the running task
+  self:run("\3")
 end
 
 function T:create_and_open_win(buf)

--- a/lua/sf/term.lua
+++ b/lua/sf/term.lua
@@ -4,11 +4,17 @@ local Term = {}
 local H = {}
 local t
 
--- this function is called in config.lua
+-- this function is called in config.lua if terminal type is set to 'integrated'
 -- it's meant to delay the raw term initialization so the term_cfg is ready after user's setup() call
 ---@param term_cfg table
-function Term.setup(term_cfg)
+function Term.integrated_setup(term_cfg)
   t = require("sf.sub.raw_term"):new(term_cfg)
+end
+
+-- this function is called in config.lua if terminal type is set to 'overseer'
+---@param overseer_cfg table
+function Term.overseer_setup(overseer_cfg)
+  t = require("sf.sub.overseer_term"):new(overseer_cfg)
 end
 
 function Term.toggle()
@@ -135,8 +141,7 @@ function Term.run_highlighted_soql()
 end
 
 function Term.cancel()
-  t.is_running = false -- set the flag to stop the running task
-  t:run("\3")
+  t:cancel()
 end
 
 function Term.go_to_sf_root()

--- a/tests/test_config.lua
+++ b/tests/test_config.lua
@@ -71,6 +71,7 @@ T["setup()"]["has default config"] = function()
     hl = "Normal",
     clear_env = false,
   })
+  expect_config("terminal", "internal")
   expect_config("default_dir", "/force-app/main/default/")
   expect_config("plugin_folder_name", "/sf_cache/")
   expect_config("auto_display_code_sign", true)


### PR DESCRIPTION
First of all, thank you for a really useful plugin.

Just as a personal preference, I would like to be able to run terminal command using overseer.nvim instead of the built in terminal. If I find that useful, I'm sure others would also.  

This PR is my naive attempt at getting this working and to get feedback.

To enable the functionality, set `terminal = "overseer"` in the setup. Now, terminal commands will be sent to overseer as tasks and should appear in the task list as per normal. No additional configuration is supported at this time.


