### PR TITLE
fix: clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@
 - [Installation](#%EF%B8%8F--installation)
 - [Configuration](#%EF%B8%8F-configuration)
 - [Keys](#-keys)
-- [Full doc](#-full-document)
 - [List/retrieve metadata](#-feature-listretrieve-metadata-and-metadata-types)
 - [Apex test](#apex-test)
 - [Display target org and code coverage](#-display-target_org-and-code-coverage)
 - [Terminal](#%EF%B8%8F-terminal)
 - [Apex jump](#-enhanced-jump-to-definition-apex)
+- [Read More](#-read-more)
 - [Contributions](#-contributions)
 
 ## ✨ Features
@@ -267,12 +267,6 @@ vim.keymap.set('n', '<leader>sk', require('sf').run('ls -la'), { noremap = true,
 ```
 <br>
 
-## 📚 Full Document
-
-Checking all features via `:h sf.nvim` or [help.txt file](https://github.com/xixiaofinland/sf.nvim/blob/dev/doc/sf.txt).
-
-<br>
-
 ## 🚀 Feature: List/retrieve metadata and metadata types
 
 Sometimes you don't know what metadata the target org contains, and you want to
@@ -438,6 +432,12 @@ ctags](https://github.com/universal-ctags/ctags). So you need to install it to u
 Using the `<C-]>` key for jump-to-definition will automatically use both LSP and ctags in order.
 `:SF create ctagsAndList` or `require('sf').create_and_list_ctags()` will update ctags and list the tags symbols in  `fzf-lua`
 plugin.
+
+<br>
+
+## 📚 Read More
+
+Full documentation can be accessed via `:h sf.nvim` or [help.txt file](https://github.com/xixiaofinland/sf.nvim/blob/dev/doc/sf.txt).
 
 <br>
 


### PR DESCRIPTION
Just had some very minor suggestions.

This is an awesome project! I hope to adopt this and contribute some more exciting than this in the future.

I suggested [fix: replace Full Docs with Read More and move to bottom](https://github.com/xixiaofinland/sf.nvim/commit/d0f05b2775e3030daf0f08ea1fc53ca57475ee6f) because currently, it's nested between different headings that may or may not be relevant.  A new user reading the `README`, I would assume that I'd go to the full docs only if the content above doesn't answer my questions.

Actually, I would also suggest centralizing all the docs and moving them off of the README entirely (except for maybe an intro and some initial quickstart steps). I imagine maintaining two different docs is harder than keeping it all in one place. I've seen other repos use the GitHub wiki feature, but also I notice you said the full docs are auto-generated, so maybe there's a better approach.