### PR TITLE
feat: update fzf_opts to table params

### DIFF
--- a/lua/sf/md.lua
+++ b/lua/sf/md.lua
@@ -107,16 +107,20 @@ H.list_md_to_retrieve = function()
         end)
       end,
     },
-    fzf_opts = {
-      ["--preview-window"] = "nohidden,down,50%",
-      ["--preview"] = function(items)
-        local contents = {}
-        vim.tbl_map(function(x)
-          table.insert(contents, "\n" .. U.table_to_string_lines(md[x]))
-        end, items)
-        return contents
-      end,
+    winopts = {
+      preview = {
+        layout = "vertical",
+        hidden = false,
+        vertical = "down:50%",
+      },
     },
+    preview = function(items)
+      local contents = {}
+      vim.tbl_map(function(x)
+        table.insert(contents, "\n" .. U.table_to_string_lines(md[x]))
+      end, items)
+      return contents
+    end,
   })
 end
 

--- a/lua/sf/org.lua
+++ b/lua/sf/org.lua
@@ -83,18 +83,22 @@ H.pull_log = function()
     end
 
     require("fzf-lua").fzf_exec(log_names, {
-      fzf_opts = {
-        ["--preview-window"] = "nohidden,down,50%",
-        ["--preview"] = function(items)
-          local contents = {}
-          local prepend_char = ""
-          vim.tbl_map(function(x)
-            table.insert(contents, prepend_char .. U.table_to_string_lines(logs[x]))
-            prepend_char = "\n"
-          end, items)
-          return contents
-        end,
+      winopts = {
+        preview = {
+          layout = "vertical",
+          hidden = false,
+          vertical = "down:50%",
+        },
       },
+      preview = function(items)
+        local contents = {}
+        local prepend_char = ""
+        vim.tbl_map(function(x)
+          table.insert(contents, prepend_char .. U.table_to_string_lines(logs[x]))
+          prepend_char = "\n"
+        end, items)
+        return contents
+      end,
       actions = {
         ["default"] = function(selected)
           log_id = logs[selected[1]]["Id"]
@@ -131,7 +135,7 @@ H.set_target_org = function()
   }, function(choice)
     if choice ~= nil then
       local org = string.gsub(choice, "%[S%] ", "")
-      local cmd = "sf config set target-org \"" .. org .. "\""
+      local cmd = 'sf config set target-org "' .. org .. '"'
       local err_msg = org .. " - set target_org failed! Not in a sfdx project folder?"
       local cb = function()
         U.target_org = org


### PR DESCRIPTION
This updates calls to `fzf-lua` to pass preview function and previewer window options as table parameters instead as of cli flags.

I'm not sure exactly **when** this happened, but over the last few days, the `fzf` preview window started failing on me. First, the preview stopped working, showing instead an `sh` error. Then today, the entire command stopped working, instead showing an error related to the options passed in `--preview-window`. 

To be honest, couldn't find exactly what changed where, but I found that all the options we were setting as flags in `fzf_opts` could be set as `opts` table params in `fzf_exec`, and that the preview function was not being passed into the underlying `fzf` command (which my best guess is what was causing the `sh` error, since it was finding the next flag as part of the `--preview` flag.

After some testing, this change keeps everything working and looking as it was before, just using params instead of flags.