### PR TITLE
fix: handle non-sf-project error in VimLeavePre autocmd

### DIFF
--- a/lua/sf/sub/config_auto_cmd.lua
+++ b/lua/sf/sub/config_auto_cmd.lua
@@ -95,9 +95,14 @@ M.set_auto_cmd_and_try_set_default_keys = function()
 
   -- clear diff files retrieved locally when Nvim exists
   vim.api.nvim_create_autocmd("VimLeavePre", {
+    group = sf_group,
     callback = function()
-      local diff_folder = U.get_plugin_folder_path() .. "diffs/"
-      vim.fn.delete(diff_folder, "rf")
+      local ok, diff_folder = pcall(function()
+        return U.get_plugin_folder_path() .. "diffs/"
+      end)
+      if ok then
+        vim.fn.delete(diff_folder, "rf")
+      end
     end,
   })
 end


### PR DESCRIPTION
Closes issue #329

- Wrap `VimLeavePre` callback body in `pcall` to handle `get_sf_root()` error when quitting Neovim outside a Salesforce project
- Add missing `group = sf_group` for consistency with all other autocmds in the function