### PR TITLE
fix: corrected pattern in nivm_create_autocmd

### DIFF
--- a/lua/sf/sub/config_auto_cmd.lua
+++ b/lua/sf/sub/config_auto_cmd.lua
@@ -8,10 +8,10 @@ M.set_auto_cmd_and_try_set_default_keys = function()
   -- Because metadata files retrieved from Salesforce don't have it
   vim.api.nvim_create_autocmd({ "FileType" }, {
     group = sf_group,
-    pattern = { "javascript, apex, html" },
+    pattern = { "javascript", "apex", "html" },
     callback = function()
       if pcall(require("sf.util").get_sf_root) then
-        vim.bo.fixendofline = false -- FIXME: it seems not set correctly. Check why.
+        vim.bo.fixendofline = false
       end
     end,
   })

--- a/tests/test_config.lua
+++ b/tests/test_config.lua
@@ -51,6 +51,18 @@ T["setup()"]["has filetypes defined"] = function()
   eq(child.lua_get("vim.bo.filetype"), "html")
 end
 
+T["setup()"]["sets fixendofline=false for javascript files in sf project"] = function()
+  child.open_in_sf_dir("hello.js")
+  eq(child.lua_get("vim.bo.filetype"), "javascript")
+  eq(child.lua_get("vim.bo.fixendofline"), false)
+end
+
+T["setup()"]["sets fixendofline=false for html files in sf project"] = function()
+  child.open_in_sf_dir("page.html")
+  eq(child.lua_get("vim.bo.filetype"), "html")
+  eq(child.lua_get("vim.bo.fixendofline"), false)
+end
+
 T["setup()"]["has default config"] = function()
   eq(child.lua_get("type(vim.g.sf)"), "table")
 


### PR DESCRIPTION
- Corrected the "fixendofline" autocmd pattern from a single comma-separated string to a proper Lua table, so it actually matches "javascript", "apex", and "html" filetypes
- Removed the related FIXME comment, as this was the root cause
- Add tests covering the fix for "javascript" and "html" filetypes