### PR TITLE
fix: add missing return after empty selection check in run_highlighted soql

### DIFF
--- a/lua/sf/term.lua
+++ b/lua/sf/term.lua
@@ -158,8 +158,9 @@ function Term.run_highlighted_soql()
   end
 
   local selected_text = H.get_visual_selection()
-  if not selected_text then
+  if U.is_empty_str(selected_text) then
     vim.notify("Empty selection.", vim.log.levels.WARN)
+    return
   end
 
   -- local raw_cmd = string.format('sf data query -q "%s" -o %s', selected_text, U.get())


### PR DESCRIPTION
The empty selection guard used "not selected_text", but "get_visual_selection()" 
returns "vim.fn.getreg()" which is always a string.

An empty selection yields "", which is truthy in Lua.

The guard never triggered, and even if it did, there was no return to prevent falling through to the command builder.

Changed to "U.is_empty_str()" with a return, matching the pattern in 
"run_anonymous_stdin" (line 104).