### PR TITLE
fix: use is_table_empty instead of is_empty_str for check in set_global_target_org

### DIFF
--- a/lua/sf/org.lua
+++ b/lua/sf/org.lua
@@ -147,9 +147,7 @@ H.set_target_org = function()
 end
 
 H.set_global_target_org = function()
-  if U.is_empty_str(H.orgs) then
-    U.notify_then_error("Empty value")
-  end
+  U.is_table_empty(H.orgs)
 
   vim.ui.select(H.orgs, {
     prompt = "Global target_org:",

--- a/tests/test_org.lua
+++ b/tests/test_org.lua
@@ -30,4 +30,12 @@ end
 --   expect.error(function() child.lua([[M.get()]]) end)
 -- end
 
+T["set_global_target_org"] = new_set()
+
+T["set_global_target_org"]["errors when org list is empty"] = function()
+  expect.error(function()
+    child.lua([[M.set_global_target_org()]])
+  end)
+end
+
 return T


### PR DESCRIPTION
H.set_global_target_org guards against an empty org list with is_empty_str(H.orgs), but H.orgs is a table. is_empty_str checks for nil or "", so the guard never triggers.

This means calling set_global_target_org before orgs are fetched shows an empty picker instead of an error. Replaced with is_table_empty to match set_target_org, store_orgs, and diff_in_org methods.

Also a test for this.