### PR TITLE
feat: possibility to run tests with --concise

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ require('sf').setup({
     covered = { fg = "#b7f071" }, -- set `fg = ""` to disable this sign icon
     uncovered = { fg = "#f07178" }, -- set `fg = ""` to disable this sign icon
   },
+
+  run_concise_tests = false, -- set to true to append --concise flag to test runs
+
 })
 ```
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,6 @@
 # sf.nvim
 - use native tree-sitter API rather than the package (v0.11 not supported anymore)
 
-- simplified test-result: The apex run test and apex get test commands now have a new --concise flag
-
 - FIXME apex test run doesn't end the running flag
 - FIXME main branch allows me to push commit directly
 

--- a/lua/sf/config.lua
+++ b/lua/sf/config.lua
@@ -78,6 +78,9 @@ local default_cfg = {
   -- wait time for sf commands (in minutes)
   -- running all local tests still defaults to 180 mins, as it is a costly operation
   sf_wait_time = 5,
+
+  -- run tests with concise flag
+  run_concise_tests = false,
 }
 
 local apply_config = function(opt)

--- a/lua/sf/sub/cmd_builder.lua
+++ b/lua/sf/sub/cmd_builder.lua
@@ -77,6 +77,15 @@ function CommandBuilder:addParams(...)
   return self
 end
 
+---Conditionally add a parameter
+---@param cond boolean
+---@param ... string|table
+---@return CommandBuilder
+function CommandBuilder:addParamIf(cond, ...)
+  if cond then return self:addParams(...) end
+  return self
+end
+
 ---Add one or more parameters, but don't expand the values
 ---@param ... string|table Either a flag and value as separate arguments, or a table of flag-value pairs
 ---@return CommandBuilder

--- a/lua/sf/test.lua
+++ b/lua/sf/test.lua
@@ -43,6 +43,7 @@ Test.run_current_test_with_coverage = function()
       ["-w"] = vim.g.sf.sf_wait_time,
       ["-c"] = "",
     })
+    :addParamIf(vim.g.sf.run_concise_tests, "--concise")
     :build()
 
   U.last_tests = cmd
@@ -71,6 +72,7 @@ Test.run_current_test = function()
       ["-r"] = "human",
       ["-w"] = vim.g.sf.sf_wait_time,
     })
+    :addParamIf(vim.g.sf.run_concise_tests, "--concise")
     :build()
 
   U.last_tests = cmd
@@ -92,6 +94,7 @@ Test.run_all_tests_in_this_file_with_coverage = function()
       ["-w"] = vim.g.sf.sf_wait_time,
       ["-c"] = "",
     })
+    :addParamIf(vim.g.sf.run_concise_tests, "--concise")
     :build()
 
   U.last_tests = cmd
@@ -115,6 +118,7 @@ Test.run_all_tests_in_this_file = function(cb)
       ["-r"] = "human",
       ["-w"] = vim.g.sf.sf_wait_time,
     })
+    :addParamIf(vim.g.sf.run_concise_tests, "--concise")
     :build()
 
   U.last_tests = cmd
@@ -140,6 +144,7 @@ Test.run_local_tests = function()
       ["-r"] = "human",
       ["-w"] = 180,
     })
+    :addParamIf(vim.g.sf.run_concise_tests, "--concise")
     :build()
 
   U.last_tests = cmd
@@ -271,7 +276,7 @@ P.set_keys = function()
       test_params = test_params .. " -t " .. test
     end
 
-    local cmd = cmd_builder:addParamStr(test_params):build()
+    local cmd = cmd_builder:addParamStr(test_params):addParamIf(vim.g.sf.run_concise_tests, "--concise"):build()
 
     return cmd
   end

--- a/tests/test_cmd_builder.lua
+++ b/tests/test_cmd_builder.lua
@@ -173,4 +173,16 @@ T["setup()"]["localOnly() by-passes the org param"] = function()
   eq(result, expected)
 end
 
+T["setup()"]["addParamIf() adds param when condition is true"] = function()
+  local result = child.lua_get('B:new():cmd("apex"):act("run"):addParamIf(true, "--concise"):build()')
+  local expected = 'sf apex run --concise -o "t_org"'
+  eq(result, expected)
+end
+
+T["setup()"]["addParamIf() skips param when condition is false"] = function()
+  local result = child.lua_get('B:new():cmd("apex"):act("run"):addParamIf(false, "--concise"):build()')
+  local expected = 'sf apex run -o "t_org"'
+  eq(result, expected)
+end
+
 return T


### PR DESCRIPTION
Added run_concise_tests (Boolean, default false) config option to that appends the --concise flag to all Apex test run commands when true.