### PR TITLE
fix: auto enable concise tests for non coverage methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,6 @@ require('sf').setup({
     uncovered = { fg = "#f07178" }, -- set `fg = ""` to disable this sign icon
   },
 
-  run_concise_tests = false, -- set to true to append --concise flag to test runs
-
 })
 ```
 

--- a/lua/sf/config.lua
+++ b/lua/sf/config.lua
@@ -79,8 +79,6 @@ local default_cfg = {
   -- running all local tests still defaults to 180 mins, as it is a costly operation
   sf_wait_time = 5,
 
-  -- run tests with concise flag
-  run_concise_tests = false,
 }
 
 local apply_config = function(opt)

--- a/lua/sf/sub/cmd_builder.lua
+++ b/lua/sf/sub/cmd_builder.lua
@@ -77,14 +77,6 @@ function CommandBuilder:addParams(...)
   return self
 end
 
----Conditionally add a parameter
----@param cond boolean
----@param ... string|table
----@return CommandBuilder
-function CommandBuilder:addParamIf(cond, ...)
-  if cond then return self:addParams(...) end
-  return self
-end
 
 ---Add one or more parameters, but don't expand the values
 ---@param ... string|table Either a flag and value as separate arguments, or a table of flag-value pairs

--- a/lua/sf/test.lua
+++ b/lua/sf/test.lua
@@ -43,7 +43,6 @@ Test.run_current_test_with_coverage = function()
       ["-w"] = vim.g.sf.sf_wait_time,
       ["-c"] = "",
     })
-    :addParamIf(vim.g.sf.run_concise_tests, "--concise")
     :build()
 
   U.last_tests = cmd
@@ -73,7 +72,6 @@ Test.run_current_test = function()
       ["-w"] = vim.g.sf.sf_wait_time,
       ["--concise"] = "",
     })
-    :addParamIf(vim.g.sf.run_concise_tests, "--concise")
     :build()
 
   U.last_tests = cmd
@@ -95,7 +93,6 @@ Test.run_all_tests_in_this_file_with_coverage = function()
       ["-w"] = vim.g.sf.sf_wait_time,
       ["-c"] = "",
     })
-    :addParamIf(vim.g.sf.run_concise_tests, "--concise")
     :build()
 
   U.last_tests = cmd
@@ -120,7 +117,6 @@ Test.run_all_tests_in_this_file = function(cb)
       ["-w"] = vim.g.sf.sf_wait_time,
       ["--concise"] = "",
     })
-    :addParamIf(vim.g.sf.run_concise_tests, "--concise")
     :build()
 
   U.last_tests = cmd
@@ -146,7 +142,6 @@ Test.run_local_tests = function()
       ["-r"] = "human",
       ["-w"] = 180,
     })
-    :addParamIf(vim.g.sf.run_concise_tests, "--concise")
     :build()
 
   U.last_tests = cmd
@@ -278,7 +273,7 @@ P.set_keys = function()
       test_params = test_params .. " -t " .. test
     end
 
-    local cmd = cmd_builder:addParamStr(test_params):addParamIf(vim.g.sf.run_concise_tests, "--concise"):build()
+    local cmd = cmd_builder:addParamStr(test_params):build()
 
     return cmd
   end

--- a/lua/sf/test.lua
+++ b/lua/sf/test.lua
@@ -71,6 +71,7 @@ Test.run_current_test = function()
       ["-t"] = test_class_name .. "." .. test_name,
       ["-r"] = "human",
       ["-w"] = vim.g.sf.sf_wait_time,
+      ["--concise"] = "",
     })
     :addParamIf(vim.g.sf.run_concise_tests, "--concise")
     :build()
@@ -117,6 +118,7 @@ Test.run_all_tests_in_this_file = function(cb)
       ["-n"] = test_class_name,
       ["-r"] = "human",
       ["-w"] = vim.g.sf.sf_wait_time,
+      ["--concise"] = "",
     })
     :addParamIf(vim.g.sf.run_concise_tests, "--concise")
     :build()

--- a/tests/test_cmd_builder.lua
+++ b/tests/test_cmd_builder.lua
@@ -173,16 +173,5 @@ T["setup()"]["localOnly() by-passes the org param"] = function()
   eq(result, expected)
 end
 
-T["setup()"]["addParamIf() adds param when condition is true"] = function()
-  local result = child.lua_get('B:new():cmd("apex"):act("run"):addParamIf(true, "--concise"):build()')
-  local expected = 'sf apex run --concise -o "t_org"'
-  eq(result, expected)
-end
-
-T["setup()"]["addParamIf() skips param when condition is false"] = function()
-  local result = child.lua_get('B:new():cmd("apex"):act("run"):addParamIf(false, "--concise"):build()')
-  local expected = 'sf apex run -o "t_org"'
-  eq(result, expected)
-end
 
 return T


### PR DESCRIPTION
This PR auto enables the --concise test running flag to run_current_test and run_all_tests_in_this_file which run without gathering coverage.

Removed the previous configurable implementation since --concise test runs strip the class coverage table away from the output. Methods running for coverage would want that table.