### PR TITLE
fix: handle empty org list gracefully in headless mode

### DIFF
--- a/lua/sf/org.lua
+++ b/lua/sf/org.lua
@@ -129,7 +129,9 @@ H.clean_org_cache = function()
 end
 
 H.set_target_org = function()
-  U.is_table_empty(H.orgs)
+  if vim.tbl_isempty(H.orgs) then
+    return U.show_err("No orgs available. Run :SF org list first.")
+  end
   vim.ui.select(H.orgs, {
     prompt = "Local target_org:",
   }, function(choice)
@@ -147,7 +149,9 @@ H.set_target_org = function()
 end
 
 H.set_global_target_org = function()
-  U.is_table_empty(H.orgs)
+  if vim.tbl_isempty(H.orgs) then
+    return U.show_err("No orgs available. Run :SF org list first.")
+  end
 
   vim.ui.select(H.orgs, {
     prompt = "Global target_org:",
@@ -188,8 +192,6 @@ H.store_orgs = function(data)
     local org_entry = v.isScratch and "[S] " .. alias or alias
     table.insert(H.orgs, org_entry)
   end
-
-  U.is_table_empty(H.orgs)
 end
 
 H.fetch_and_store_orgs = function()


### PR DESCRIPTION
## Problem

Running `nvim --headless` crashes during plugin initialization with error:

```
Lua callback: .../sf/util.lua:25: Sf: Empty table
```

This occurs when:
- No Salesforce orgs are configured
- Running in headless mode (CI/build systems)  
- During asynchronous org list fetch at startup

## Root Cause

The `store_orgs()` function calls `U.is_table_empty(H.orgs)` after populating the org list. This function throws an error if the table is empty, which is a valid state when no orgs exist.

## Solution

- Remove the error-throwing validation after `store_orgs()`
- Add graceful error handling in `set_target_org()` and `set_global_target_org()`
- Allow headless initialization to complete successfully

## Testing

- ✅ `nvim --headless -c 'qa'` works with no orgs
- ✅ `nvim --headless -c 'qa'` works with orgs configured
- ✅ Manual org selection still shows error when no orgs available

## Changes

- Remove 1 line: error-throwing validation in `store_orgs()`
- Replace 2 validations: graceful error messages instead of crashes