### PR TITLE
fix: update stale set_global_target_org test assertion

### DIFF
--- a/tests/test_org.lua
+++ b/tests/test_org.lua
@@ -32,10 +32,11 @@ end
 
 T["set_global_target_org"] = new_set()
 
-T["set_global_target_org"]["errors when org list is empty"] = function()
-  expect.error(function()
-    child.lua([[M.set_global_target_org()]])
-  end)
+T["set_global_target_org"]["does not open selector when org list is empty"] = function()
+  child.lua([[
+    vim.ui.select = function() error("must not be called") end
+    M.set_global_target_org()
+  ]])
 end
 
 return T


### PR DESCRIPTION
## Summary

- `U.show_err` calls `vim.notify` and does not throw a Lua error
- The old `expect.error` wrapper was accidentally passing because the previous guard (`is_empty_str({})`) threw on a table argument — that bug was fixed in c62a06c, leaving the test broken
- New assertion verifies the actual invariant: `vim.ui.select` is **not** called when the org list is empty

## Test plan

- [ ] Run `make test` — `set_global_target_org` case passes
- [ ] Re-trigger CI on PR #340 — the org test no longer fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)